### PR TITLE
重构小行星联动逻辑并支持双公司变体

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -1,0 +1,29 @@
+name: Server Tests
+
+on:
+  push:
+    branches: [ main ]  # 只在 main 分支的 push 上运行
+  pull_request:
+    branches: [ main ]  # 也会在向 main 的 PR 上运行
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18  # 项目支持 16~22，这里选了一个稳定的中间值
+
+      - name: Install dependencies
+        run: npm ci  # 使用 lock 文件快速安装依赖
+
+      - name: Build static files
+        run: npm run make:static  # 生成测试所需文件
+
+      - name: Run server tests
+        run: npm run test:server  # 调用测试脚本

--- a/src/client/components/SelectInitialCards.vue
+++ b/src/client/components/SelectInitialCards.vue
@@ -230,16 +230,16 @@ export default (Vue as WithRefs<Refs>).extend({
       const corporation2 = getCardOrThrow(corpName2);
 
       // 计算初始MC，并减去42（针对双公司的特殊调整）
-      let startingMegaCredits = 
-        ((corporation1.startingMegaCredits ?? 0) + 
+      let startingMegaCredits =
+        ((corporation1.startingMegaCredits ?? 0) +
         (corporation2.startingMegaCredits ?? 0) - 42);
 
       // 计算并减去留牌费用
-      const cardCost = 
-        (((corporation1.cardCost ?? constants.CARD_COST) + 
-          (corporation2.cardCost ?? constants.CARD_COST)) - 
+      const cardCost =
+        (((corporation1.cardCost ?? constants.CARD_COST) +
+          (corporation2.cardCost ?? constants.CARD_COST)) -
         constants.CARD_COST);
-      
+
       startingMegaCredits -= this.selectedCards.length * cardCost;
 
       return startingMegaCredits;
@@ -265,7 +265,7 @@ export default (Vue as WithRefs<Refs>).extend({
         if (this.selectedCorporations.length === 2) {
           result.responses.push({
             type: 'card',
-            cards: this.selectedCorporations,  // 选择2张公司卡
+            cards: this.selectedCorporations, // 选择2张公司卡
           });
         } else {
           this.warning = 'You need to select exactly 2 corporations';
@@ -275,7 +275,7 @@ export default (Vue as WithRefs<Refs>).extend({
         if (this.selectedCorporations.length === 1) {
           result.responses.push({
             type: 'card',
-            cards: [this.selectedCorporations[0]],  // 选择1张公司卡
+            cards: [this.selectedCorporations[0]], // 选择1张公司卡
           });
         } else if (this.selectedCorporations.length > 1) {
           this.warning = 'You selected too many corporations';
@@ -400,13 +400,16 @@ export default (Vue as WithRefs<Refs>).extend({
       return hasOption(this.playerinput.options, titles.SELECT_TWO_CORPORATIONS_TITLE);
     },
     corpCardOption() {
-      const title = this.isDoubleCorpVariantEnabled
-        ? titles.SELECT_TWO_CORPORATIONS_TITLE
-        : titles.SELECT_CORPORATION_TITLE;
+      const title = this.isDoubleCorpVariantEnabled ?
+        titles.SELECT_TWO_CORPORATIONS_TITLE :
+        titles.SELECT_CORPORATION_TITLE;
 
       const option = getOption(this.playerinput.options, title);
-      option.min = this.isDoubleCorpVariantEnabled ? 2 : 1;
-      option.max = this.isDoubleCorpVariantEnabled ? 2 : option.cards.length;
+      if (getPreferences().experimental_ui) {
+        // UI 实验功能下仍支持选择所有公司卡，min 受双公司影响
+        option.min = this.isDoubleCorpVariantEnabled ? 2 : 1;
+        option.max = option.cards?.length ?? 0;
+      }
       return option;
     },
     preludeCardOption() {

--- a/src/client/components/board/BoardSpaceTile.vue
+++ b/src/client/components/board/BoardSpaceTile.vue
@@ -54,7 +54,7 @@ const tileTypeToCssClass: Record<TileType, string> = {
   [TileType.MARS_NOMADS]: '', // This never actually renders.
   [TileType.REY_SKYWALKER]: 'martian-nature-wonders', // Use Martian Nature Wonders cube CSS.
   [TileType.MAN_MADE_VOLCANO]: 'man-made-volcano',
-  [TileType.GAMBLING_DISTRICT_LAS_VEGAS]: 'gambling-district-las-vegas', 
+  [TileType.GAMBLING_DISTRICT_LAS_VEGAS]: 'gambling-district-las-vegas',
 };
 
 const tileTypeToCssClassAresOverride = new Map<TileType, string>([

--- a/src/client/components/card/Card.vue
+++ b/src/client/components/card/Card.vue
@@ -201,7 +201,7 @@ export default Vue.extend({
         return this.card.lastProjectCardCost;
       }
       return undefined;
-    }
+    },
   },
 });
 

--- a/src/common/TileType.ts
+++ b/src/common/TileType.ts
@@ -59,7 +59,7 @@ export enum TileType {
     MAN_MADE_VOLCANO, // 42
 
     // MingYue
-    GAMBLING_DISTRICT_LAS_VEGAS, //43
+    GAMBLING_DISTRICT_LAS_VEGAS, // 43
   }
 
 export const tileTypeToString: Record<TileType, string> = {

--- a/src/common/cards/render/CardRenderItemType.ts
+++ b/src/common/cards/render/CardRenderItemType.ts
@@ -12,7 +12,7 @@ export enum CardRenderItemType {
   MEGACREDITS = 'megacredits',
   MEGACREDITSTEXT = 'megacredits_text',
   CARDS = 'cards',
-  ONE_SET = 'one_set', 
+  ONE_SET = 'one_set',
   TAG = 'tag',
   RESOURCE = 'resource',
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,4 +1,4 @@
-import { IGame } from "../server/IGame";
+import {IGame} from '../server/IGame';
 
 // Base constants
 export const CARD_COST = 3;

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -82,7 +82,7 @@ import {newStandardDraft} from './Draft';
 import {Message} from '../common/logs/Message';
 import {DiscordId} from './server/auth/discord';
 import {GoldenFinger} from './cards/mingyue/GoldenFinger';
-import { WorldLineVoyager } from './cards/mingyue/WorldLineVoyager';
+import {WorldLineVoyager} from './cards/mingyue/WorldLineVoyager';
 
 const THROW_STATE_ERRORS = Boolean(process.env.THROW_STATE_ERRORS);
 const DEFAULT_GLOBAL_PARAMETER_STEPS = {
@@ -919,7 +919,7 @@ export class Player implements IPlayer {
     // See DeclareCloneTag for why this skips cards with clone tags.
     if (!selectedCard.tags.includes(Tag.CLONE) && cardAction !== 'double-down') {
       this.onCardPlayed(selectedCard);
-      if(payment!==undefined){
+      if (payment !== undefined) {
         this.onCardPlayedWithPayment(selectedCard, payment);
       }
     }
@@ -1616,21 +1616,21 @@ export class Player implements IPlayer {
           worldlinevoyager.isOneActionThisRound = !worldlinevoyager.isOneActionThisRound;
           // 根据 isOneActionThisRound 调整恢复的行动次数
           if (worldlinevoyager.isOneActionThisRound) {
-            this.availableActionsThisRound = 1;  // 每回合只有一次行动
+            this.availableActionsThisRound = 1; // 每回合只有一次行动
             this.game.log(
               '${0}\'s ${1} has jumped to the α World Line. You can take 1 action next round.',
-              (b) => b.player(this).card(worldlinevoyager)
+              (b) => b.player(this).card(worldlinevoyager),
             );
           } else {
-            this.availableActionsThisRound = 3;  // 每回合可以恢复三次行动
+            this.availableActionsThisRound = 3; // 每回合可以恢复三次行动
             this.game.log(
               '${0}\'s ${1} has jumped to the β World Line. You can take 3 actions next round.',
-              (b) => b.player(this).card(worldlinevoyager)
+              (b) => b.player(this).card(worldlinevoyager),
             );
           }
         } else {
           // 如果没有世界线航行者公司，恢复默认的行动次数
-          this.availableActionsThisRound = 2;  // 默认每回合2次行动
+          this.availableActionsThisRound = 2; // 默认每回合2次行动
         }
         this.actionsTakenThisRound = 0;
         game.resettable = true;

--- a/src/server/cards/mingyue/ArtifactHarvest.ts
+++ b/src/server/cards/mingyue/ArtifactHarvest.ts
@@ -1,11 +1,11 @@
-import { IProjectCard } from '../IProjectCard';
-import { CardType } from '../../../common/cards/CardType';
-import { CardName } from '../../../common/cards/CardName';
-import { CardRenderer } from '../render/CardRenderer';
-import { Card } from '../Card';
-import { Tag } from '../../../common/cards/Tag';
-import { IPlayer } from '../../../server/IPlayer';
-import { Resource } from '../../../common/Resource';
+import {IProjectCard} from '../IProjectCard';
+import {CardType} from '../../../common/cards/CardType';
+import {CardName} from '../../../common/cards/CardName';
+import {CardRenderer} from '../render/CardRenderer';
+import {Card} from '../Card';
+import {Tag} from '../../../common/cards/Tag';
+import {IPlayer} from '../../../server/IPlayer';
+import {Resource} from '../../../common/Resource';
 
 export class ArtifactHarvest extends Card implements IProjectCard {
   constructor() {
@@ -14,7 +14,7 @@ export class ArtifactHarvest extends Card implements IProjectCard {
       name: CardName.ARTIFACT_HARVEST,
       tags: [Tag.PLANT],
       cost: 7,
-      requirements: { oceans: 7 },
+      requirements: {oceans: 7},
       victoryPoints: 1,
       behavior: {},
       metadata: {
@@ -27,7 +27,7 @@ export class ArtifactHarvest extends Card implements IProjectCard {
               eb.text('X').wild(1).asterix()
                 .startEffect
                 .text('X').plants(1);
-            }
+            },
           );
         }),
       },
@@ -37,13 +37,13 @@ export class ArtifactHarvest extends Card implements IProjectCard {
   public override play(player: IPlayer) {
     // 计算玩家拥有的不同种类的非标准资源数量
     const nonStandardResources = new Set(
-      player.getCardsWithResources().map((card) => card.resourceType)
+      player.getCardsWithResources().map((card) => card.resourceType),
     ).size;
 
     // 每种非标准资源给予1植物，总计最多7植物（对应7种资源）
     const plantGain = Math.min(nonStandardResources, 7);
 
-    player.stock.add(Resource.PLANTS, plantGain, { log: true });
+    player.stock.add(Resource.PLANTS, plantGain, {log: true});
     return undefined;
   }
 }

--- a/src/server/cards/mingyue/AsteroidMaterialResearchCenter.ts
+++ b/src/server/cards/mingyue/AsteroidMaterialResearchCenter.ts
@@ -1,14 +1,14 @@
-import { IProjectCard } from '../IProjectCard';
-import { Card } from '../Card';
-import { CardName } from '../../../common/cards/CardName';
-import { CardType } from '../../../common/cards/CardType';
-import { Tag } from '../../../common/cards/Tag';
-import { CardResource } from '../../../common/CardResource';
-import { IPlayer } from '../../IPlayer';
-import { ICard, isIActionCard } from '../ICard';
-import { CardRenderer } from '../render/CardRenderer';
-import { SelectCard } from '../../inputs/SelectCard';
-import { AltSecondaryTag } from '../../../common/cards/render/AltSecondaryTag';
+import {IProjectCard} from '../IProjectCard';
+import {Card} from '../Card';
+import {CardName} from '../../../common/cards/CardName';
+import {CardType} from '../../../common/cards/CardType';
+import {Tag} from '../../../common/cards/Tag';
+import {CardResource} from '../../../common/CardResource';
+import {IPlayer} from '../../IPlayer';
+import {ICard, isIActionCard} from '../ICard';
+import {CardRenderer} from '../render/CardRenderer';
+import {SelectCard} from '../../inputs/SelectCard';
+import {AltSecondaryTag} from '../../../common/cards/render/AltSecondaryTag';
 
 export class AsteroidMaterialResearchCenter extends Card implements IProjectCard {
   private static readonly COST = 15;
@@ -33,18 +33,18 @@ export class AsteroidMaterialResearchCenter extends Card implements IProjectCard
             eb.empty()
               .resource(CardResource.ASTEROID)
               .startEffect
-              .cards(1, { secondaryTag: AltSecondaryTag.BLUE })
+              .cards(1, {secondaryTag: AltSecondaryTag.BLUE})
               .myLoopArrow()
-              .asterix()
+              .asterix(),
           ).br;
 
           // 效果2：当你打出名字中含有 "asteroid" 的事件牌时，为任意一张卡添加一个陨石资源
           b.effect('When you play an event card with "asteroid" in its name, add 1 asteroid resource to any card', (eb) =>
-            eb.cards(1, { secondaryTag: Tag.EVENT })
+            eb.cards(1, {secondaryTag: Tag.EVENT})
               .myAsteroid()
               .startEffect
               .resource(CardResource.ASTEROID)
-              .asterix()
+              .asterix(),
           );
         }),
       },
@@ -54,7 +54,7 @@ export class AsteroidMaterialResearchCenter extends Card implements IProjectCard
   // 效果1触发：蓝卡获得陨石资源时尝试刷新该卡行动
   public onResourceAdded(player: IPlayer, card: ICard): void {
     if (card.resourceType !== CardResource.ASTEROID) return; // 不是陨石资源
-    if (!isIActionCard(card)) return;                         // 不是蓝卡
+    if (!isIActionCard(card)) return; // 不是蓝卡
     if (!player.actionsThisGeneration.has(card.name)) return; // 本代未使用，不需要刷新
 
     const currentGeneration = player.game.generation;
@@ -74,7 +74,7 @@ export class AsteroidMaterialResearchCenter extends Card implements IProjectCard
 
     player.game.log(
       '${0} 的 ${1} 获得陨石资源，行动被刷新（第 ${2} 次）',
-      (b) => b.player(player).card(card).number(currentCount + 1)
+      (b) => b.player(player).card(card).number(currentCount + 1),
     );
   }
 
@@ -94,7 +94,7 @@ export class AsteroidMaterialResearchCenter extends Card implements IProjectCard
 
     // 如果只有一张卡可以添加资源，则直接添加
     if (asteroidCards.length === 1) {
-      thisCardOwner.addResourceTo(asteroidCards[0], { qty: 1, log: true });
+      thisCardOwner.addResourceTo(asteroidCards[0], {qty: 1, log: true});
       return undefined;
     }
 
@@ -102,9 +102,9 @@ export class AsteroidMaterialResearchCenter extends Card implements IProjectCard
     return new SelectCard(
       'Select a card to add 1 asteroid resource',
       'Add asteroid',
-      asteroidCards as ICard[]
+      asteroidCards as ICard[],
     ).andThen(([selected]) => {
-      thisCardOwner.addResourceTo(selected, { qty: 1, log: true });
+      thisCardOwner.addResourceTo(selected, {qty: 1, log: true});
       return undefined;
     });
   }

--- a/src/server/cards/mingyue/EcologicalPavilion.ts
+++ b/src/server/cards/mingyue/EcologicalPavilion.ts
@@ -1,9 +1,9 @@
-import { IProjectCard } from '../IProjectCard';
-import { Tag } from '../../../common/cards/Tag';
-import { Card } from '../Card';
-import { CardType } from '../../../common/cards/CardType';
-import { CardName } from '../../../common/cards/CardName';
-import { CardRenderer } from '../render/CardRenderer';
+import {IProjectCard} from '../IProjectCard';
+import {Tag} from '../../../common/cards/Tag';
+import {Card} from '../Card';
+import {CardType} from '../../../common/cards/CardType';
+import {CardName} from '../../../common/cards/CardName';
+import {CardRenderer} from '../render/CardRenderer';
 
 export class EcologicalPavilion extends Card implements IProjectCard {
   constructor() {
@@ -14,9 +14,9 @@ export class EcologicalPavilion extends Card implements IProjectCard {
       cost: 10,
       victoryPoints: 1,
       requirements: [
-        { tag: Tag.PLANT },
-        { tag: Tag.MICROBE },
-        { tag: Tag.ANIMAL },
+        {tag: Tag.PLANT},
+        {tag: Tag.MICROBE},
+        {tag: Tag.ANIMAL},
       ],
 
       behavior: {

--- a/src/server/cards/mingyue/FloralBloomSurge.ts
+++ b/src/server/cards/mingyue/FloralBloomSurge.ts
@@ -1,11 +1,11 @@
-import { IProjectCard } from '../IProjectCard';
-import { Tag } from '../../../common/cards/Tag';
-import { Card } from '../Card';
-import { CardType } from '../../../common/cards/CardType';
-import { IPlayer } from '../../IPlayer';
-import { CardName } from '../../../common/cards/CardName';
-import { CardRenderer } from '../render/CardRenderer';
-import { Resource } from '../../../common/Resource';
+import {IProjectCard} from '../IProjectCard';
+import {Tag} from '../../../common/cards/Tag';
+import {Card} from '../Card';
+import {CardType} from '../../../common/cards/CardType';
+import {IPlayer} from '../../IPlayer';
+import {CardName} from '../../../common/cards/CardName';
+import {CardRenderer} from '../render/CardRenderer';
+import {Resource} from '../../../common/Resource';
 
 export class FloralBloomSurge extends Card implements IProjectCard {
   constructor() {
@@ -19,7 +19,7 @@ export class FloralBloomSurge extends Card implements IProjectCard {
         cardNumber: 'MY06',
         renderData: CardRenderer.builder((b) => {
           b.effect('When you play a plant tag card (including this), increase your plant production by 1.', (eb) => {
-            eb.tag(Tag.PLANT).startEffect.production((pb) => pb.plants(1))
+            eb.tag(Tag.PLANT).startEffect.production((pb) => pb.plants(1));
           });
         }),
       },
@@ -29,7 +29,7 @@ export class FloralBloomSurge extends Card implements IProjectCard {
   public onCardPlayed(player: IPlayer, card: IProjectCard) {
     const tagCount = player.tags.cardTagCount(card, Tag.PLANT);
     if (tagCount > 0) {
-        player.production.add(Resource.PLANTS, tagCount, {log: true});
+      player.production.add(Resource.PLANTS, tagCount, {log: true});
     }
   }
 }

--- a/src/server/cards/mingyue/GamblingDistrictLasVegas.ts
+++ b/src/server/cards/mingyue/GamblingDistrictLasVegas.ts
@@ -1,16 +1,16 @@
-import { CardName } from '../../../common/cards/CardName';
-import { TileType } from '../../../common/TileType';
-import { CardRenderer } from '../render/CardRenderer';
-import { CardType } from '../../../common/cards/CardType';
-import { IProjectCard } from '../IProjectCard';
-import { Card } from '../Card';
-import { Tag } from '../../../common/cards/Tag';
-import { IPlayer } from '../../../server/IPlayer';
-import { Space } from '../../../server/boards/Space';
-import { BoardType } from '../../../server/boards/BoardType';
-import { SpaceType } from '../../../common/boards/SpaceType';
-import { Resource } from '../../../common/Resource';
-import { all } from '../Options';
+import {CardName} from '../../../common/cards/CardName';
+import {TileType} from '../../../common/TileType';
+import {CardRenderer} from '../render/CardRenderer';
+import {CardType} from '../../../common/cards/CardType';
+import {IProjectCard} from '../IProjectCard';
+import {Card} from '../Card';
+import {Tag} from '../../../common/cards/Tag';
+import {IPlayer} from '../../../server/IPlayer';
+import {Space} from '../../../server/boards/Space';
+import {BoardType} from '../../../server/boards/BoardType';
+import {SpaceType} from '../../../common/boards/SpaceType';
+import {Resource} from '../../../common/Resource';
+import {all} from '../Options';
 
 export class GamblingDistrictLasVegas extends Card implements IProjectCard {
   constructor() {
@@ -20,7 +20,7 @@ export class GamblingDistrictLasVegas extends Card implements IProjectCard {
       tags: [Tag.BUILDING, Tag.CITY],
       cost: 20,
       behavior: {
-        production: { energy: -1, megacredits: 3 },
+        production: {energy: -1, megacredits: 3},
         tile: {
           type: TileType.GAMBLING_DISTRICT_LAS_VEGAS,
           on: 'city',
@@ -44,16 +44,16 @@ export class GamblingDistrictLasVegas extends Card implements IProjectCard {
           });
           b.br;
           b.plainEffect('When a tile is placed adjacent to it, the player must pay 3 M€ more, then roll 1d6 to gain that many M€.', (eb) => {
-            eb.megacreditsText("-3", { all })
+            eb.megacreditsText('-3', {all})
               .nbsp
               .myXDian()
-              .startEffect.megacreditsText("+X", { all });
+              .startEffect.megacreditsText('+X', {all});
           });
           b.br;
           b.plainEffect('If the result is 5 or 6, they also draw a card.', (eb) => {
             eb.my5Dian()
               .my6Dian()
-              .startEffect.cards(1, { all });
+              .startEffect.cards(1, {all});
           });
         }),
         description: '',
@@ -72,7 +72,7 @@ export class GamblingDistrictLasVegas extends Card implements IProjectCard {
     // 遍历周围格子，检查是否邻接赌城
     const adjacentSpaces = game.board.getAdjacentSpaces(space);
     const isAdjacentToGamblingDistrict = adjacentSpaces.some(
-      (adjSpace) => adjSpace.tile?.tileType === TileType.GAMBLING_DISTRICT_LAS_VEGAS
+      (adjSpace) => adjSpace.tile?.tileType === TileType.GAMBLING_DISTRICT_LAS_VEGAS,
     );
 
     if (!isAdjacentToGamblingDistrict) {
@@ -95,12 +95,12 @@ export class GamblingDistrictLasVegas extends Card implements IProjectCard {
     if (drewCard) {
       game.log(
         '${0} rolled ${1} and gained ${2} M€, then drew a card from ${3}.',
-        (b) => b.player(activePlayer).number(diceRoll).number(diceRoll).card(this)
+        (b) => b.player(activePlayer).number(diceRoll).number(diceRoll).card(this),
       );
     } else {
       game.log(
         '${0} rolled ${1} and gained ${2} M€ from ${3}.',
-        (b) => b.player(activePlayer).number(diceRoll).number(diceRoll).card(this)
+        (b) => b.player(activePlayer).number(diceRoll).number(diceRoll).card(this),
       );
     }
   }

--- a/src/server/cards/mingyue/GoldenFinger.ts
+++ b/src/server/cards/mingyue/GoldenFinger.ts
@@ -1,31 +1,31 @@
-import { CorporationCard } from '../corporation/CorporationCard';
-import { CardName } from '../../../common/cards/CardName';
-import { CardRenderer } from '../render/CardRenderer';
-import { IActionCard, ICard, isIActionCard, isIHasCheckLoops } from '../ICard';
-import { IPlayer } from '../../IPlayer';
-import { SelectCard } from '../../inputs/SelectCard';
-import { OrOptions } from '../../inputs/OrOptions';
-import { SelectOption } from '../../inputs/SelectOption';
-import { SelectAmount } from '../../inputs/SelectAmount';
-import { ChooseCards } from '../../deferredActions/ChooseCards';
-import { GainResources } from '../../inputs/GainResources';
-import { Size } from '../../../common/cards/render/Size';
+import {CorporationCard} from '../corporation/CorporationCard';
+import {CardName} from '../../../common/cards/CardName';
+import {CardRenderer} from '../render/CardRenderer';
+import {IActionCard, ICard, isIActionCard, isIHasCheckLoops} from '../ICard';
+import {IPlayer} from '../../IPlayer';
+import {SelectCard} from '../../inputs/SelectCard';
+import {OrOptions} from '../../inputs/OrOptions';
+import {SelectOption} from '../../inputs/SelectOption';
+import {SelectAmount} from '../../inputs/SelectAmount';
+import {ChooseCards} from '../../deferredActions/ChooseCards';
+import {GainResources} from '../../inputs/GainResources';
+import {Size} from '../../../common/cards/render/Size';
 
 export class GoldenFinger extends CorporationCard {
-    constructor() {
-      super({
-        name: CardName.GOLDEN_FINGER,
-        tags: [],
-        startingMegaCredits: 999,
-        metadata: {
-          cardNumber: 'MY-CORP-04',
-          description: '可无限执行公司行动，内含测试工具。',
-          renderData: CardRenderer.builder((b) => {
-            b.megacredits(999, { size: Size.LARGE });
-          }),
-        },
-      });
-    }
+  constructor() {
+    super({
+      name: CardName.GOLDEN_FINGER,
+      tags: [],
+      startingMegaCredits: 999,
+      metadata: {
+        cardNumber: 'MY-CORP-04',
+        description: '可无限执行公司行动，内含测试工具。',
+        renderData: CardRenderer.builder((b) => {
+          b.megacredits(999, {size: Size.LARGE});
+        }),
+      },
+    });
+  }
 
   public canAct(): boolean {
     return true;
@@ -64,7 +64,7 @@ export class GoldenFinger extends CorporationCard {
     // 行动 3：展示牌堆顶 X 张牌，保留 1 张
     const revealDeck = new SelectOption('展示牌堆顶 X 张牌，保留 1 张', 'Reveal').andThen(() => {
       return new SelectAmount('输入要展示的牌数（最多保留1张）', '确定', 1, 1000, true).andThen((amount) => {
-        player.drawCardKeepSome(amount, { keepMax: 1 });
+        player.drawCardKeepSome(amount, {keepMax: 1});
         return undefined;
       });
     });
@@ -74,11 +74,14 @@ export class GoldenFinger extends CorporationCard {
       return new SelectAmount('输入要展示的牌数（最多保留1张）', '确定', 1, 1000, true).andThen((amount) => {
         const selectedCards = [];
         for (let idx = 0; idx < amount && player.game.projectDeck.discardPile.length > 0; idx++) {
-          selectedCards.push(player.game.projectDeck.discardPile.pop()!);
+          const card = player.game.projectDeck.discardPile.pop();
+          if (card) {
+            selectedCards.push(card);
+          }
         }
 
         const keepCount = Math.min(1, selectedCards.length);
-        player.game.defer(new ChooseCards(player, selectedCards, { keepMax: keepCount }));
+        player.game.defer(new ChooseCards(player, selectedCards, {keepMax: keepCount}));
         return undefined;
       });
     });
@@ -94,10 +97,10 @@ export class GoldenFinger extends CorporationCard {
       return new SelectCard(
         '选择一个已使用过的蓝卡来再次行动',
         '使用',
-        actionCards
+        actionCards,
       ).andThen(([card]) => {
         player.game.log('${0} 使用了 ${1} 的行动（来自 ${2}）', (b) =>
-          b.player(player).card(card).card(this)
+          b.player(player).card(card).card(this),
         );
         return card.action(player);
       });

--- a/src/server/cards/mingyue/InfiniteMonkeyTheorem.ts
+++ b/src/server/cards/mingyue/InfiniteMonkeyTheorem.ts
@@ -1,14 +1,14 @@
-import { IProjectCard } from '../IProjectCard';
-import { IActionCard } from '../ICard';
-import { Card } from '../Card';
-import { CardType } from '../../../common/cards/CardType';
-import { Tag } from '../../../common/cards/Tag';
-import { CardName } from '../../../common/cards/CardName';
-import { CardResource } from '../../../common/CardResource';
-import { CardRenderer } from '../render/CardRenderer';
-import { IPlayer } from '../../IPlayer';
-import { Resource } from '../../../common/Resource';
-import { Size } from '../../../common/cards/render/Size';
+import {IProjectCard} from '../IProjectCard';
+import {IActionCard} from '../ICard';
+import {Card} from '../Card';
+import {CardType} from '../../../common/cards/CardType';
+import {Tag} from '../../../common/cards/Tag';
+import {CardName} from '../../../common/cards/CardName';
+import {CardResource} from '../../../common/CardResource';
+import {CardRenderer} from '../render/CardRenderer';
+import {IPlayer} from '../../IPlayer';
+import {Resource} from '../../../common/Resource';
+import {Size} from '../../../common/cards/render/Size';
 
 export class InfiniteMonkeyTheorem extends Card implements IProjectCard, IActionCard {
   // 存储所有曾经展示的牌
@@ -31,14 +31,14 @@ export class InfiniteMonkeyTheorem extends Card implements IProjectCard, IAction
               eb.empty()
                 .startAction.cards(1).asterix()
                 .nbsp.diverseTag().slash().resource(CardResource.MONKEY).asterix();
-            }
+            },
           ).br;
           b.plainEffect(
             'Then gain 1M€ per animal here.',
             (eb) => {
               eb.empty().startEffect
                 .resource(CardResource.MONKEY).slash().megacredits(1);
-            }
+            },
           ).br;
           b.text('Cannot gain animals by other means.', Size.SMALL, true);
         }),
@@ -86,10 +86,10 @@ export class InfiniteMonkeyTheorem extends Card implements IProjectCard, IAction
     }
 
     player.game.log('${0} linked ${1} with ${2}', (b) =>
-      b.player(player).card(topCard).card(this)
+      b.player(player).card(topCard).card(this),
     );
 
-    player.stock.add(Resource.MEGACREDITS, this.resourceCount, { log: true });
+    player.stock.add(Resource.MEGACREDITS, this.resourceCount, {log: true});
 
     return undefined;
   }

--- a/src/server/cards/mingyue/LunaChain.ts
+++ b/src/server/cards/mingyue/LunaChain.ts
@@ -28,7 +28,7 @@ export class LunaChain extends CorporationCard {
               'When the actual paid M€ of your current and previous project cards differ by X (X < 3), gain (3 - X) M€.',
               (eb) => {
                 eb.cards(1).megacreditsText('M').minus().megacreditsText('N').text('<3').startEffect.megacreditsText('3-X').asterix();
-              }
+              },
             );
           });
         }),
@@ -57,7 +57,7 @@ export class LunaChain extends CorporationCard {
 
         player.game.log(
           '${0} gained ${1} M€ due to ${2} effect.',
-          (b) => b.player(player).number(gain).card(this)
+          (b) => b.player(player).number(gain).card(this),
         );
 
         const avg = this.lunaChainTotalGain / this.lunaChainProjectCardCount;
@@ -75,7 +75,7 @@ export class LunaChain extends CorporationCard {
 
         player.game.log(
           '${0} has accumulated ${1} M€, averaging ${2} M€ per project card (' + title + ')',
-          (b) => b.player(player).number(this.lunaChainTotalGain).number(parseFloat(avg.toFixed(2)))
+          (b) => b.player(player).number(this.lunaChainTotalGain).number(parseFloat(avg.toFixed(2))),
         );
       }
     }
@@ -85,7 +85,7 @@ export class LunaChain extends CorporationCard {
 
     player.game.log(
       'The next card costs ${0} M€ to maximize the LunaChain skill',
-      (b) => b.number(actualCost)
+      (b) => b.number(actualCost),
     );
   }
 }

--- a/src/server/cards/mingyue/MingYueCardManifest.ts
+++ b/src/server/cards/mingyue/MingYueCardManifest.ts
@@ -1,19 +1,19 @@
-import { CardName } from '../../../common/cards/CardName';
-import { ModuleManifest } from '../ModuleManifest';
-import { ProjectReorganization } from './ProjectReorganization';
-import { AsteroidMaterialResearchCenter} from './AsteroidMaterialResearchCenter';
-import { TrisynInstitute } from './TrisynInstitute';
-import { LunaChain } from './LunaChain';
-import { Tithes } from './Tithes';
-import { ResourcePlanningBureau } from './ResourcePlanningBureau';
-import { SpaceWedding } from './SpaceWedding';
-import { InfiniteMonkeyTheorem } from './InfiniteMonkeyTheorem';
-import { GoldenFinger } from './GoldenFinger';
-import { FloralBloomSurge } from './FloralBloomSurge';
-import { EcologicalPavilion } from './EcologicalPavilion';
-import { GamblingDistrictLasVegas } from './GamblingDistrictLasVegas';
-import { ArtifactHarvest } from './ArtifactHarvest';
-import { WorldLineVoyager } from './WorldLineVoyager';
+import {CardName} from '../../../common/cards/CardName';
+import {ModuleManifest} from '../ModuleManifest';
+import {ProjectReorganization} from './ProjectReorganization';
+import {AsteroidMaterialResearchCenter} from './AsteroidMaterialResearchCenter';
+import {TrisynInstitute} from './TrisynInstitute';
+import {LunaChain} from './LunaChain';
+import {Tithes} from './Tithes';
+import {ResourcePlanningBureau} from './ResourcePlanningBureau';
+import {SpaceWedding} from './SpaceWedding';
+import {InfiniteMonkeyTheorem} from './InfiniteMonkeyTheorem';
+import {GoldenFinger} from './GoldenFinger';
+import {FloralBloomSurge} from './FloralBloomSurge';
+import {EcologicalPavilion} from './EcologicalPavilion';
+import {GamblingDistrictLasVegas} from './GamblingDistrictLasVegas';
+import {ArtifactHarvest} from './ArtifactHarvest';
+import {WorldLineVoyager} from './WorldLineVoyager';
 
 export const MINGYUE_CARD_MANIFEST = new ModuleManifest({
   module: 'mingyue',

--- a/src/server/cards/mingyue/ProjectReorganization.ts
+++ b/src/server/cards/mingyue/ProjectReorganization.ts
@@ -25,7 +25,7 @@ export class ProjectReorganization extends Card implements IProjectCard {
         renderData: CardRenderer.builder((b) => {
           b.action(
             'Spend 2 energy to look at the top 4 cards of the discard pile. Keep 1 and return the rest in order.',
-            (eb) => eb.energy(ProjectReorganization.ENERGY_COST, {digit}).startAction.text('4').cards(1).asterix()
+            (eb) => eb.energy(ProjectReorganization.ENERGY_COST, {digit}).startAction.text('4').cards(1).asterix(),
           );
         }),
       },
@@ -43,7 +43,10 @@ export class ProjectReorganization extends Card implements IProjectCard {
 
     const selectedCards = [];
     for (let idx = 0; idx < 4 && player.game.projectDeck.discardPile.length > 0; idx++) {
-      selectedCards.push(player.game.projectDeck.discardPile.pop()!);
+      const card = player.game.projectDeck.discardPile.pop();
+      if (card) {
+        selectedCards.push(card);
+      }
     }
 
     const keepCount = Math.min(1, selectedCards.length);

--- a/src/server/cards/mingyue/ResourcePlanningBureau.ts
+++ b/src/server/cards/mingyue/ResourcePlanningBureau.ts
@@ -1,12 +1,12 @@
-import { IProjectCard } from '../IProjectCard';
-import { Card } from '../Card';
-import { CardName } from '../../../common/cards/CardName';
-import { CardType } from '../../../common/cards/CardType';
-import { Tag } from '../../../common/cards/Tag';
-import { IPlayer } from '../../IPlayer';
-import { ICard } from '../ICard';
-import { CardRenderer } from '../render/CardRenderer';
-import { Payment } from '../../../common/inputs/Payment';
+import {IProjectCard} from '../IProjectCard';
+import {Card} from '../Card';
+import {CardName} from '../../../common/cards/CardName';
+import {CardType} from '../../../common/cards/CardType';
+import {Tag} from '../../../common/cards/Tag';
+import {IPlayer} from '../../IPlayer';
+import {ICard} from '../ICard';
+import {CardRenderer} from '../render/CardRenderer';
+import {Payment} from '../../../common/inputs/Payment';
 
 export class ResourcePlanningBureau extends Card implements IProjectCard {
   constructor() {
@@ -24,7 +24,7 @@ export class ResourcePlanningBureau extends Card implements IProjectCard {
             eb.cards(1).text('pay')
               .megacreditsText('0').wild(1).asterix()
               .startEffect
-              .megacredits(2)
+              .megacredits(2),
           );
         }),
       },
@@ -36,14 +36,14 @@ export class ResourcePlanningBureau extends Card implements IProjectCard {
     if (![CardType.AUTOMATED, CardType.ACTIVE, CardType.EVENT].includes(card.type)) return;
 
     // 确保支付的 M€ 为 0，且支付了至少1个其他资源
-    if (payment.megaCredits === 0 && Object.values(payment).some(value => value > 0)) {
-        const gain = 2;
-        player.megaCredits += 2;
+    if (payment.megaCredits === 0 && Object.values(payment).some((value) => value > 0)) {
+      const gain = 2;
+      player.megaCredits += 2;
 
-        player.game.log(
-            '${0} gained ${1} M€ from ${2} effect.',
-            (b) => b.player(player).number(gain).card(this)
-        );
+      player.game.log(
+        '${0} gained ${1} M€ from ${2} effect.',
+        (b) => b.player(player).number(gain).card(this),
+      );
     }
   }
 }

--- a/src/server/cards/mingyue/SpaceWedding.ts
+++ b/src/server/cards/mingyue/SpaceWedding.ts
@@ -1,18 +1,18 @@
-import { IProjectCard } from '../IProjectCard';
-import { Card } from '../Card';
-import { CardName } from '../../../common/cards/CardName';
-import { CardType } from '../../../common/cards/CardType';
-import { IPlayer } from '../../IPlayer';
-import { CardRenderer } from '../render/CardRenderer';
-import { SelectCard } from '../../inputs/SelectCard';
-import { DeferredAction } from '../../deferredActions/DeferredAction';
-import { Priority } from '../../deferredActions/Priority';
-import { OrOptions } from '../../inputs/OrOptions';
-import { SelectOption } from '../../inputs/SelectOption';
-import { message } from '../../logs/MessageBuilder';
-import { all } from '../Options';
-import { LogHelper } from '../../../server/LogHelper';
-import { Tag } from '../../../common/cards/Tag';
+import {IProjectCard} from '../IProjectCard';
+import {Card} from '../Card';
+import {CardName} from '../../../common/cards/CardName';
+import {CardType} from '../../../common/cards/CardType';
+import {IPlayer} from '../../IPlayer';
+import {CardRenderer} from '../render/CardRenderer';
+import {SelectCard} from '../../inputs/SelectCard';
+import {DeferredAction} from '../../deferredActions/DeferredAction';
+import {Priority} from '../../deferredActions/Priority';
+import {OrOptions} from '../../inputs/OrOptions';
+import {SelectOption} from '../../inputs/SelectOption';
+import {message} from '../../logs/MessageBuilder';
+import {all} from '../Options';
+import {LogHelper} from '../../../server/LogHelper';
+import {Tag} from '../../../common/cards/Tag';
 
 export class SpaceWedding extends Card implements IProjectCard {
   constructor() {
@@ -25,7 +25,7 @@ export class SpaceWedding extends Card implements IProjectCard {
       metadata: {
         cardNumber: 'MY04',
         renderData: CardRenderer.builder((b) =>
-          b.cards(1).cards(1, { all }).asterix()
+          b.cards(1).cards(1, {all}).asterix(),
         ),
         description: 'Reveal 2 cards. Keep one and give the other to another player.',
       },
@@ -51,7 +51,9 @@ class SelectWeddingCard extends DeferredAction {
 
   public execute() {
     return new SelectCard('Select a card to keep', 'Keep', this.cards).andThen(([kept]) => {
-      const other = this.cards.find(c => c !== kept)!;
+      const other = this.cards.find((c) => c !== kept);
+      if (!other) throw new Error('Expected to find another card');
+      const assuredOther = other as IProjectCard;
       this.player.cardsInHand.push(kept);
 
       const game = this.player.game;
@@ -60,18 +62,18 @@ class SelectWeddingCard extends DeferredAction {
       const otherPlayers = this.player.getOpponents();
 
       if (otherPlayers.length === 0) {
-        game.projectDeck.discard(other);
-        game.log('No other players. ${0} was discarded.', (b) => b.card(other));
+        game.projectDeck.discard(assuredOther);
+        game.log('No other players. ${0} was discarded.', (b) => b.card(assuredOther));
         return undefined;
       }
 
       const options = new OrOptions();
       otherPlayers.forEach((target) => {
         options.options.push(new SelectOption(
-          message('Give ${0} to ${1}', (b) => b.card(other).player(target))
+          message('Give ${0} to ${1}', (b) => b.card(assuredOther).player(target)),
         ).andThen(() => {
-          target.cardsInHand.push(other);
-          game.log('${0} gave ${1} to ${2}', (b) => b.player(this.player).card(other).player(target));
+          target.cardsInHand.push(assuredOther);
+          game.log('${0} gave ${1} to ${2}', (b) => b.player(this.player).card(assuredOther).player(target));
           return undefined;
         }));
       });

--- a/src/server/cards/mingyue/Tithes.ts
+++ b/src/server/cards/mingyue/Tithes.ts
@@ -1,11 +1,11 @@
-import { Tag } from '../../../common/cards/Tag';
-import { CorporationCard } from '../corporation/CorporationCard';
-import { CardName } from '../../../common/cards/CardName';
-import { CardRenderer } from '../render/CardRenderer';
-import { IPlayer } from '../../IPlayer';
-import { all } from '../Options';
-import { Resource } from '../../../common/Resource';
-import { Size } from '../../../common/cards/render/Size';
+import {Tag} from '../../../common/cards/Tag';
+import {CorporationCard} from '../corporation/CorporationCard';
+import {CardName} from '../../../common/cards/CardName';
+import {CardRenderer} from '../render/CardRenderer';
+import {IPlayer} from '../../IPlayer';
+import {all} from '../Options';
+import {Resource} from '../../../common/Resource';
+import {Size} from '../../../common/cards/render/Size';
 
 export class Tithes extends CorporationCard {
   constructor() {
@@ -26,20 +26,20 @@ export class Tithes extends CorporationCard {
                 eb
                   .empty()
                   .startAction
-                  .minus().megacreditsText('X', { all })
+                  .minus().megacreditsText('X', {all})
                   .nbsp.plus().megacreditsText('ΣX')
                   .asterix();
-              }
+              },
             );
             cb.vSpace(Size.SMALL);
             cb.plainEffect(
               'Each other player who loses 3 M€ or more due to this action draws 1 card.',
               (eb) => {
                 eb
-                  .megacreditsText('X', { all }).text('>=').megacredits(3, { all })
-                  .startEffect.cards(1, { all })
+                  .megacreditsText('X', {all}).text('>=').megacredits(3, {all})
+                  .startEffect.cards(1, {all})
                   .asterix();
-              }
+              },
             );
           });
         }),
@@ -61,19 +61,19 @@ export class Tithes extends CorporationCard {
       const amount = Math.floor(opponent.megaCredits / 10);
 
       if (amount > 0) {
-        opponent.attack(player, Resource.MEGACREDITS, amount, { stealing: true, log: false });
+        opponent.attack(player, Resource.MEGACREDITS, amount, {stealing: true, log: false});
         totalStolen += amount;
 
         if (amount >= 3) {
           opponent.drawCard(1);
           player.game.log(
             '${0} paid ${1} M€ in ${2} and draws 1 card.',
-            (b) => b.player(opponent).number(amount).card(this)
+            (b) => b.player(opponent).number(amount).card(this),
           );
         } else {
           player.game.log(
             '${0} paid ${1} M€ in ${2}.',
-            (b) => b.player(opponent).number(amount).card(this)
+            (b) => b.player(opponent).number(amount).card(this),
           );
         }
       }
@@ -82,7 +82,7 @@ export class Tithes extends CorporationCard {
     if (totalStolen > 0) {
       player.game.log(
         '${0} collected a total of ${1} M€ via ${2}.',
-        (b) => b.player(player).number(totalStolen).card(this)
+        (b) => b.player(player).number(totalStolen).card(this),
       );
     }
   }

--- a/src/server/cards/mingyue/TrisynInstitute.ts
+++ b/src/server/cards/mingyue/TrisynInstitute.ts
@@ -8,10 +8,9 @@ import {CardType} from '../../../common/cards/CardType';
 import {Size} from '../../../common/cards/render/Size';
 import {SelectCard} from '../../inputs/SelectCard';
 import {PlayerInput} from '../../../server/PlayerInput';
-import { LogHelper } from '../../../server/LogHelper';
+import {LogHelper} from '../../../server/LogHelper';
 
 export class TrisynInstitute extends CorporationCard {
-
   private lastComboCount = 0;
 
   constructor() {
@@ -113,7 +112,7 @@ export class TrisynInstitute extends CorporationCard {
       this.lastComboCount = currentComboCount;
       player.game.log(
         '收集了 ${0} 套红绿蓝卡牌，抽 1 张牌',
-        (b) => b.number(currentComboCount)
+        (b) => b.number(currentComboCount),
       );
       player.drawCard(1);
     }

--- a/src/server/cards/mingyue/WorldLineVoyager.ts
+++ b/src/server/cards/mingyue/WorldLineVoyager.ts
@@ -55,7 +55,7 @@ export class WorldLineVoyager extends CorporationCard {
 
     // 根据是否为1次行动或3次行动，返回卡牌的费用折扣
     if (this.isOneActionThisRound) {
-      return 3;  // 1动时，项目卡费用减少3 M€
+      return 3; // 1动时，项目卡费用减少3 M€
     } else {
       return -1; // 3动时，项目卡费用增加1 M€
     }

--- a/src/server/cards/promo/AsteroidRights.ts
+++ b/src/server/cards/promo/AsteroidRights.ts
@@ -64,14 +64,14 @@ export class AsteroidRights extends Card implements IActionCard, IProjectCard {
 
     const gainTitaniumOption = new SelectOption('Remove 1 asteroid on this card to gain 2 titanium', 'Remove asteroid').andThen(() => {
       player.removeResourceFrom(this, 1, {log: false});
-      player.stock.add(Resource.TITANIUM, 2, {log: false });
+      player.stock.add(Resource.TITANIUM, 2, {log: false});
       LogHelper.logRemoveResource(player, this, 1, 'gain 2 titanium');
       return undefined;
     });
 
     const increaseMcProdOption = new SelectOption('Remove 1 asteroid on this card to increase M€ production 1 step', 'Remove asteroid').andThen(() => {
       player.removeResourceFrom(this, 1, {log: false});
-      player.production.add(Resource.MEGACREDITS, 1, {log: false });
+      player.production.add(Resource.MEGACREDITS, 1, {log: false});
       LogHelper.logRemoveResource(player, this, 1, 'increase M€ production 1 step');
       return undefined;
     });

--- a/src/server/inputs/SelectInitialCards.ts
+++ b/src/server/inputs/SelectInitialCards.ts
@@ -94,15 +94,19 @@ export class SelectInitialCards extends OptionsInput<undefined> {
     const game = player.game;
 
     const [corporation1, corporation2] = corporations;
+    const isDoubleCorpVariant = corporation2 !== undefined;
 
-    // 计算留牌费用（注意：若只有1个公司，只计算1个费用）
-    const cardCost = (corporation2 !== undefined)
+    // 计算每张起始手牌的费用
+    const cardCost = isDoubleCorpVariant
     ? (((corporation1.cardCost ?? player.cardCost) + (corporation2.cardCost ?? player.cardCost)) - player.cardCost)
     : (corporation1.cardCost ?? player.cardCost);
 
     const totalCardCost = player.cardsInHand.length * cardCost;
-    // 双公司变体规则，初始MC为: 两公司mc总和-42
-    const availableCredits = (corporation1.startingMegaCredits ?? 0) + (corporation2?.startingMegaCredits ?? 0) - 42;
+
+    // 计算起始可用 M€
+    const availableCredits = isDoubleCorpVariant
+    ? ((corporation1.startingMegaCredits ?? 0) + (corporation2?.startingMegaCredits ?? 0) - 42)
+    : (corporation1.startingMegaCredits ?? 0);
 
     if (corporation1.name !== CardName.BEGINNER_CORPORATION && totalCardCost > availableCredits) {
       player.cardsInHand = [];

--- a/src/server/inputs/SelectInitialCards.ts
+++ b/src/server/inputs/SelectInitialCards.ts
@@ -12,7 +12,7 @@ import {InputResponse, isSelectInitialCardsResponse} from '../../common/inputs/I
 export class SelectInitialCards extends OptionsInput<undefined> {
   constructor(
     private player: IPlayer,
-    cb: (corporations: ICorporationCard[]) => undefined
+    cb: (corporations: ICorporationCard[]) => undefined,
   ) {
     super('initialCards', '', []);
     const game = player.game;
@@ -97,16 +97,16 @@ export class SelectInitialCards extends OptionsInput<undefined> {
     const isDoubleCorpVariant = corporation2 !== undefined;
 
     // 计算每张起始手牌的费用
-    const cardCost = isDoubleCorpVariant
-    ? (((corporation1.cardCost ?? player.cardCost) + (corporation2.cardCost ?? player.cardCost)) - player.cardCost)
-    : (corporation1.cardCost ?? player.cardCost);
+    const cardCost = isDoubleCorpVariant ?
+      (((corporation1.cardCost ?? player.cardCost) + (corporation2.cardCost ?? player.cardCost)) - player.cardCost) :
+      (corporation1.cardCost ?? player.cardCost);
 
     const totalCardCost = player.cardsInHand.length * cardCost;
 
     // 计算起始可用 M€
-    const availableCredits = isDoubleCorpVariant
-    ? ((corporation1.startingMegaCredits ?? 0) + (corporation2?.startingMegaCredits ?? 0) - 42)
-    : (corporation1.startingMegaCredits ?? 0);
+    const availableCredits = isDoubleCorpVariant ?
+      ((corporation1.startingMegaCredits ?? 0) + (corporation2?.startingMegaCredits ?? 0) - 42) :
+      (corporation1.startingMegaCredits ?? 0);
 
     if (corporation1.name !== CardName.BEGINNER_CORPORATION && totalCardCost > availableCredits) {
       player.cardsInHand = [];
@@ -114,7 +114,7 @@ export class SelectInitialCards extends OptionsInput<undefined> {
       throw new InputError('Too many cards selected');
     }
 
-    const selectedNames = corporations.map(c => c.name);
+    const selectedNames = corporations.map((c) => c.name);
     for (const card of player.dealtCorporationCards) {
       if (!selectedNames.includes(card.name)) {
         game.corporationDeck.discard(card);

--- a/src/server/models/ModelUtils.ts
+++ b/src/server/models/ModelUtils.ts
@@ -11,8 +11,8 @@ import {IColony} from '../colonies/IColony';
 import {CardName} from '../../common/cards/CardName';
 import {Tag} from '../../common/cards/Tag';
 import {asArray} from '../../common/utils/utils';
-import { LunaChain } from '../cards/mingyue/LunaChain';
-import { WorldLineVoyager } from '../cards/mingyue/WorldLineVoyager';
+import {LunaChain} from '../cards/mingyue/LunaChain';
+import {WorldLineVoyager} from '../cards/mingyue/WorldLineVoyager';
 
 export function cardsToModel(
   player: IPlayer,

--- a/tests/cards/mingyue/ProjectReorganization.spec.ts
+++ b/tests/cards/mingyue/ProjectReorganization.spec.ts
@@ -1,16 +1,16 @@
 import {expect} from 'chai';
-import {ProjectReorganization} from '../../../src/server/cards/community/ProjectReorganization';
+import {ProjectReorganization} from '../../../src/server/cards/mingyue/ProjectReorganization';
 import {TestPlayer} from '../../TestPlayer';
 import {IGame} from '../../../src/server/IGame';
 import {testGame} from '../../TestGame';
 import {cast, runAllActions} from '../../TestingUtils';
-import {ChooseCards} from '../../../src/server/deferredActions/ChooseCards';
 import {Ants} from '../../../src/server/cards/base/Ants';
 import {Birds} from '../../../src/server/cards/base/Birds';
 import {Capital} from '../../../src/server/cards/base/Capital';
 import {Decomposers} from '../../../src/server/cards/base/Decomposers';
 import {EarthOffice} from '../../../src/server/cards/base/EarthOffice';
 import {Resource} from '../../../src/common/Resource';
+import {SelectCard} from '../../../src/server/inputs/SelectCard';
 
 describe('ProjectReorganization', () => {
   let card: ProjectReorganization;
@@ -67,7 +67,7 @@ describe('ProjectReorganization', () => {
     card.action(player);
     runAllActions(game);
 
-    const choose = cast(player.popWaitingFor(), ChooseCards);
+    const choose = cast(player.popWaitingFor(), SelectCard);
     // 顺序是后丢的先弹出，所以 top 4 应该是：birds, capital, decomposers, earthOffice
     expect(choose.cards).to.have.members([birds, capital, decomposers, earthOffice]);
     expect(game.projectDeck.discardPile).deep.eq([ants]);
@@ -88,7 +88,7 @@ describe('ProjectReorganization', () => {
     card.action(player);
     runAllActions(game);
 
-    const choose = cast(player.popWaitingFor(), ChooseCards);
+    const choose = cast(player.popWaitingFor(), SelectCard);
     expect(choose.cards).to.have.members([ants, birds, capital]);
     expect(game.projectDeck.discardPile).is.empty;
   });

--- a/tests/cards/promo/AsteroidRights.spec.ts
+++ b/tests/cards/promo/AsteroidRights.spec.ts
@@ -73,6 +73,6 @@ describe('AsteroidRights', () => {
     const action = cast(card.action(player), OrOptions);
     expect(action.options[0] instanceof SelectOption).is.true;
     expect(action.options[1] instanceof SelectOption).is.true;
-    expect(action.options[2] instanceof SelectCard).is.true;
+    expect(action.options[2] instanceof SelectOption).is.true;
   });
 });

--- a/tests/cards/venusNext/RotatorImpacts.spec.ts
+++ b/tests/cards/venusNext/RotatorImpacts.spec.ts
@@ -7,6 +7,8 @@ import {IGame} from '../../../src/server/IGame';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {TestPlayer} from '../../TestPlayer';
 import {testGame} from '../../TestGame';
+import {Payment} from '../../../src/common/inputs/Payment';
+import {SelectPayment} from '../../../src/server/inputs/SelectPayment';
 
 describe('RotatorImpacts', () => {
   let card: RotatorImpacts;
@@ -52,6 +54,12 @@ describe('RotatorImpacts', () => {
     expect(card.canAct(player)).is.true;
 
     card.action(player);
+    expect(game.deferredActions).has.lengthOf(1);
+    const selectPayment = cast(game.deferredActions.peek()!.execute(), SelectPayment);
+    selectPayment.cb({...Payment.EMPTY, titanium: 1, megaCredits: 3});
+
+    expect(player.megaCredits).to.eq(13);
+    expect(player.titanium).to.eq(1);
     expect(card.resourceCount).to.eq(1);
   });
 

--- a/tests/inputs/SelectInitialCards.spec.ts
+++ b/tests/inputs/SelectInitialCards.spec.ts
@@ -9,11 +9,11 @@ import {toName} from '../../src/common/utils/utils';
 
 describe('SelectInitialCards', () => {
   let player: TestPlayer;
-  let corp: ICorporationCard | undefined = undefined;
+  let corp: ICorporationCard[] | undefined = undefined;
   let selectInitialCards: SelectInitialCards;
 
-  function cb(corporation: ICorporationCard) {
-    corp = corporation;
+  function cb(corporations: ICorporationCard[]) {
+    corp = corporations;
     return undefined;
   }
 
@@ -61,7 +61,7 @@ describe('SelectInitialCards', () => {
     ]}, player);
 
     expect(player.corporations).has.length(0); // This input object doesn't set the player's corporation card
-    expect(corp!.name).eq(CardName.INVENTRIX);
+    expect(corp![0].name).eq(CardName.INVENTRIX);
     expect(player.cardsInHand.map(toName)).to.have.members([CardName.ANTS]); // But it does set their cards in hand.
 
     expect(player.game.projectDeck.discardPile.map(toName)).to.have.members([CardName.BACTOVIRAL_RESEARCH, CardName.COMET_AIMING, CardName.DIRIGIBLES]);
@@ -86,7 +86,7 @@ describe('SelectInitialCards', () => {
     ]}, player);
 
     expect(player.corporations).has.length(0); // This input object doesn't set the player's corporation card
-    expect(corp!.name).eq(CardName.INVENTRIX);
+    expect(corp![0].name).eq(CardName.INVENTRIX);
     expect(player.cardsInHand.map(toName)).to.have.members([CardName.ANTS]); // But it does set their cards in hand.
     expect(player.ceoCardsInHand.map(toName)).to.have.members([CardName.ASIMOV]);
     expect(player.preludeCardsInHand.map(toName)).to.have.members([CardName.LOAN, CardName.BIOLAB]);

--- a/tests/routes/ApiCreateGame.spec.ts
+++ b/tests/routes/ApiCreateGame.spec.ts
@@ -69,6 +69,7 @@ describe('ApiCreateGame', () => {
           turmoil: false,
           community: false,
           ares: false,
+          mingyue: false,
           moon: false,
           pathfinders: false,
           ceo: false,
@@ -115,6 +116,8 @@ describe('ApiCreateGame', () => {
         customCeos: [],
         startingCeos: 0,
         startingPreludes: 0,
+        doubleCorpVariant: false,
+        sevenHeatVariant: false,
       };
       req.emitter.emit('data', JSON.stringify(newGameConfig));
       req.emitter.emit('end');

--- a/tests/routes/ApiGame.spec.ts
+++ b/tests/routes/ApiGame.spec.ts
@@ -70,6 +70,7 @@ describe('ApiGame', () => {
             'colonies': false,
             'community': false,
             'corpera': true,
+            "mingyue": false,
             'moon': false,
             'pathfinders': false,
             'prelude': false,

--- a/tests/routes/ApiGame.spec.ts
+++ b/tests/routes/ApiGame.spec.ts
@@ -70,7 +70,7 @@ describe('ApiGame', () => {
             'colonies': false,
             'community': false,
             'corpera': true,
-            "mingyue": false,
+            'mingyue': false,
             'moon': false,
             'pathfinders': false,
             'prelude': false,


### PR DESCRIPTION
## ✨ 主要改动内容

- **重构与小行星中心相关的逻辑**，修复了两张与其联动存在 bug 的卡牌，使其在触发时效果正确（如刷新行动次数等）。
- **新增对“双公司变体（Double Corp Variant）”的支持**：
  - 初始手牌费用计算调整，正确扣除两家公司和 10 张初始牌的费用。
  - 相关测试用例已更新并通过。

## 🔧 其他更新

- **添加 GitHub Actions 测试流程**，确保提交自动运行服务端测试。
- **修复部分代码格式**，以符合 GitHub Actions 的检查标准。

## ✅ 已验证

- 本地通过所有现有及新增测试用例。
- 新增双公司选项在 UI 和逻辑上均表现正常。
