### PR TITLE
feat(mingyue): 添加对 mingyueData 的初始化、持久化和序列化支持

### DIFF
--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -85,6 +85,8 @@ import {maybeRenamedAward} from '../common/ma/AwardName';
 import {Eris} from './cards/community/Eris';
 import {AresHazards} from './ares/AresHazards';
 import {hazardSeverity} from '../common/AresTileType';
+import {MingYueData} from './mingyue/MingYueData';
+import {MingYueExpansion} from './mingyue/MingYueExpansion';
 
 // Can be overridden by tests
 
@@ -155,6 +157,7 @@ export class Game implements IGame, Logger {
   public pathfindersData: PathfindersData | undefined;
   public underworldData: UnderworldData = UnderworldExpansion.initializeGameWithoutUnderworld();
   public inTurmoil: boolean = false;
+  public mingyueData: MingYueData | undefined;
 
   // Card-specific data
   // Mons Insurance promo corp
@@ -340,6 +343,10 @@ export class Game implements IGame, Logger {
       game.pathfindersData = PathfindersExpansion.initialize(game);
     }
 
+    if (gameOptions.mingyueExpansion) {
+      game.mingyueData = MingYueExpansion.initialize();
+    }
+
     // Failsafe for exceeding corporation pool
     // (I do not think this is necessary any further given how corporation cards are stored now)
     const minCorpsRequired = players.length * gameOptions.startingCorporations;
@@ -456,6 +463,7 @@ export class Game implements IGame, Logger {
       oxygenLevel: this.oxygenLevel,
       passedPlayers: Array.from(this.passedPlayers),
       pathfindersData: PathfindersData.serialize(this.pathfindersData),
+      mingyueData: MingYueData.serialize(this.mingyueData),
       phase: this.phase,
       players: this.players.map((p) => p.serialize()),
       preludeDeck: this.preludeDeck.serialize(),
@@ -1698,6 +1706,10 @@ export class Game implements IGame, Logger {
 
     if (d.pathfindersData !== undefined && gameOptions.pathfindersExpansion === true) {
       game.pathfindersData = PathfindersData.deserialize(d.pathfindersData);
+    }
+
+    if (d.mingyueData !== undefined && gameOptions.mingyueExpansion === true) {
+      game.mingyueData = MingYueData.deserialize(d.mingyueData);
     }
 
     if (d.underworldData !== undefined) {

--- a/src/server/IGame.ts
+++ b/src/server/IGame.ts
@@ -34,6 +34,7 @@ import {Logger} from './logs/Logger';
 import {GlobalParameter} from '../common/GlobalParameter';
 import {UnderworldData} from './underworld/UnderworldData';
 import {OrOptions} from './inputs/OrOptions';
+import {MingYueData} from './mingyue/MingYueData';
 
 export interface Score {
   corporation: String;
@@ -82,6 +83,7 @@ export interface IGame extends Logger {
   moonData: MoonData | undefined;
   pathfindersData: PathfindersData | undefined;
   underworldData: UnderworldData;
+  mingyueData: MingYueData | undefined;
 
   // Card-specific data
 

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -83,6 +83,7 @@ import {Message} from '../common/logs/Message';
 import {DiscordId} from './server/auth/discord';
 import {GoldenFinger} from './cards/mingyue/GoldenFinger';
 import {WorldLineVoyager} from './cards/mingyue/WorldLineVoyager';
+import {getWorldLineVoyagerData} from './mingyue/MingYueData';
 
 const THROW_STATE_ERRORS = Boolean(process.env.THROW_STATE_ERRORS);
 const DEFAULT_GLOBAL_PARAMETER_STEPS = {
@@ -1612,24 +1613,18 @@ export class Player implements IPlayer {
       ) {
         // 如果玩家拥有世界线航行者公司，则行动次数在1次、3次切换
         if (worldlinevoyager instanceof WorldLineVoyager) {
+          const data = getWorldLineVoyagerData(this.game);
           // 反转 isOneActionThisRound 状态
-          worldlinevoyager.isOneActionThisRound = !worldlinevoyager.isOneActionThisRound;
+          data.isOneActionThisRound = !data.isOneActionThisRound;
           // 根据 isOneActionThisRound 调整恢复的行动次数
-          if (worldlinevoyager.isOneActionThisRound) {
-            this.availableActionsThisRound = 1; // 每回合只有一次行动
-            this.game.log(
-              '${0}\'s ${1} has jumped to the α World Line. You can take 1 action next round.',
-              (b) => b.player(this).card(worldlinevoyager),
-            );
-          } else {
-            this.availableActionsThisRound = 3; // 每回合可以恢复三次行动
-            this.game.log(
-              '${0}\'s ${1} has jumped to the β World Line. You can take 3 actions next round.',
-              (b) => b.player(this).card(worldlinevoyager),
-            );
-          }
+          this.availableActionsThisRound = data.isOneActionThisRound ? 1 : 3;
+          this.game.log(
+            (data.isOneActionThisRound ?
+              '${0}\'s ${1} has jumped to the α World Line. You can take 1 action next round.' :
+              '${0}\'s ${1} has jumped to the β World Line. You can take 3 actions next round.'),
+            (b) => b.player(this).card(worldlinevoyager),
+          );
         } else {
-          // 如果没有世界线航行者公司，恢复默认的行动次数
           this.availableActionsThisRound = 2; // 默认每回合2次行动
         }
         this.actionsTakenThisRound = 0;

--- a/src/server/SerializedGame.ts
+++ b/src/server/SerializedGame.ts
@@ -19,6 +19,7 @@ import {AwardName} from '../common/ma/AwardName';
 import {GlobalParameter} from '../common/GlobalParameter';
 import {MilestoneName} from '../common/ma/MilestoneName';
 import {Tag} from '../common/cards/Tag';
+import {SerializedMingYueData} from './mingyue/SerializedMingYueData';
 
 export type SerializedGame = {
     activePlayer: PlayerId;
@@ -51,6 +52,7 @@ export type SerializedGame = {
     moonData: SerializedMoonData | undefined;
     nomadSpace: SpaceId | undefined;
     pathfindersData: SerializedPathfindersData | undefined;
+    mingyueData: SerializedMingYueData | undefined;
     oxygenLevel: number;
     passedPlayers: Array<PlayerId>;
     phase: Phase;

--- a/src/server/cards/mingyue/LunaChain.ts
+++ b/src/server/cards/mingyue/LunaChain.ts
@@ -6,12 +6,9 @@ import {CardType} from '../../../common/cards/CardType';
 import {ICard} from '../ICard';
 import {IPlayer} from '../../IPlayer';
 import {Payment} from '../../../common/inputs/Payment';
+import {getLunaChainData} from '../../mingyue/MingYueData';
 
 export class LunaChain extends CorporationCard {
-  private lastProjectCardMegacreditCost: number | undefined;
-  private lunaChainTotalGain: number = 0;
-  private lunaChainProjectCardCount: number = 0;
-
   constructor() {
     super({
       name: CardName.LUNA_CHAIN,
@@ -36,31 +33,34 @@ export class LunaChain extends CorporationCard {
     });
   }
 
-  getLastProjectCardMegacreditCost(): number | undefined {
-    return this.lastProjectCardMegacreditCost;
+  getLastProjectCardMegacreditCost(player: IPlayer): number | undefined {
+    return getLunaChainData(player.game).lastProjectCardMegacreditCost;
   }
 
   public onCardPlayedWithPayment(player: IPlayer, card: ICard, payment: Payment): void {
     if (!player.isCorporation(this.name)) return;
     if (![CardType.AUTOMATED, CardType.ACTIVE, CardType.EVENT].includes(card.type)) return;
 
-    const actualCost = payment.megaCredits ?? 0;
-    this.lunaChainProjectCardCount += 1;
+    const game = player.game;
+    const data = getLunaChainData(game);
 
-    if (this.lastProjectCardMegacreditCost !== undefined) {
-      const diff = Math.abs(actualCost - this.lastProjectCardMegacreditCost);
+    const actualCost = payment.megaCredits ?? 0;
+    data.projectCardCount += 1;
+
+    if (data.lastProjectCardMegacreditCost !== undefined) {
+      const diff = Math.abs(actualCost - data.lastProjectCardMegacreditCost);
 
       if (diff < 3) {
         const gain = 3 - diff;
         player.megaCredits += gain;
-        this.lunaChainTotalGain += gain;
+        data.totalGain += gain;
 
         player.game.log(
           '${0} gained ${1} M€ due to ${2} effect.',
           (b) => b.player(player).number(gain).card(this),
         );
 
-        const avg = this.lunaChainTotalGain / this.lunaChainProjectCardCount;
+        const avg = data.totalGain / data.projectCardCount;
         let title = '';
 
         if (avg >= 2.0) {
@@ -75,13 +75,13 @@ export class LunaChain extends CorporationCard {
 
         player.game.log(
           '${0} has accumulated ${1} M€, averaging ${2} M€ per project card (' + title + ')',
-          (b) => b.player(player).number(this.lunaChainTotalGain).number(parseFloat(avg.toFixed(2))),
+          (b) => b.player(player).number(data.totalGain).number(parseFloat(avg.toFixed(2))),
         );
       }
     }
 
     // 更新 lastProjectCardMegacreditCost 为当前卡的实际费用
-    this.lastProjectCardMegacreditCost = actualCost;
+    data.lastProjectCardMegacreditCost = actualCost;
 
     player.game.log(
       'The next card costs ${0} M€ to maximize the LunaChain skill',

--- a/src/server/cards/mingyue/WorldLineVoyager.ts
+++ b/src/server/cards/mingyue/WorldLineVoyager.ts
@@ -4,11 +4,9 @@ import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {IPlayer} from '../../IPlayer';
 import {Size} from '../../../common/cards/render/Size';
+import {getWorldLineVoyagerData} from '../../../server/mingyue/MingYueData';
 
 export class WorldLineVoyager extends CorporationCard {
-  // 初始为 β 世界线（3 次行动）
-  public isOneActionThisRound: boolean = false;
-
   constructor() {
     super({
       name: CardName.WORLD_LINE_VOYAGER,
@@ -43,8 +41,8 @@ export class WorldLineVoyager extends CorporationCard {
    * β 世界线：编号 2（3 次行动，isOneActionThisRound 为 false）
    * 注：Steins;Gate 世界线为设想中的第 3 条线（未使用）
    */
-  public getCurrentWorldline(): number {
-    return this.isOneActionThisRound? 1 : 2;
+  public getCurrentWorldline(player: IPlayer): number {
+    return getWorldLineVoyagerData(player.game).isOneActionThisRound? 1 : 2;
   }
 
   /**
@@ -54,7 +52,7 @@ export class WorldLineVoyager extends CorporationCard {
     if (!player.isCorporation(this.name)) return 0;
 
     // 根据是否为1次行动或3次行动，返回卡牌的费用折扣
-    if (this.isOneActionThisRound) {
+    if (getWorldLineVoyagerData(player.game).isOneActionThisRound) {
       return 3; // 1动时，项目卡费用减少3 M€
     } else {
       return -1; // 3动时，项目卡费用增加1 M€

--- a/src/server/mingyue/MingYueData.ts
+++ b/src/server/mingyue/MingYueData.ts
@@ -1,0 +1,66 @@
+import {SerializedMingYueData} from './SerializedMingYueData';
+import {IGame} from '../IGame';
+
+export interface MingYueData {
+  lunaChain?: {
+    lastProjectCardMegacreditCost?: number;
+    totalGain: number;
+    projectCardCount: number;
+  };
+  worldLineVoyager?: {
+    isOneActionThisRound: boolean;
+  };
+}
+
+export namespace MingYueData {
+  export function serialize(data: MingYueData | undefined): SerializedMingYueData | undefined {
+    if (data === undefined) return undefined;
+    return {
+      ...(data.lunaChain !== undefined && {
+        lunaChain: {
+          lastProjectCardMegacreditCost: data.lunaChain.lastProjectCardMegacreditCost,
+          totalGain: data.lunaChain.totalGain,
+          projectCardCount: data.lunaChain.projectCardCount,
+        },
+      }),
+      ...(data.worldLineVoyager !== undefined && {
+        worldLineVoyager: {
+          isOneActionThisRound: data.worldLineVoyager.isOneActionThisRound,
+        },
+      }),
+    };
+  }
+
+  export function deserialize(data: SerializedMingYueData): MingYueData {
+    return {
+      lunaChain: data.lunaChain ?
+        {
+          lastProjectCardMegacreditCost: data.lunaChain.lastProjectCardMegacreditCost ?? undefined,
+          totalGain: data.lunaChain.totalGain ?? 0,
+          projectCardCount: data.lunaChain.projectCardCount ?? 0,
+        } : undefined,
+      worldLineVoyager: data.worldLineVoyager ?
+        {
+          isOneActionThisRound: data.worldLineVoyager.isOneActionThisRound ?? false,
+        } : undefined,
+    };
+  }
+}
+
+export function getLunaChainData(game: IGame) {
+  game.mingyueData ??= {};
+  game.mingyueData.lunaChain ??= {
+    totalGain: 0,
+    projectCardCount: 0,
+    lastProjectCardMegacreditCost: undefined,
+  };
+  return game.mingyueData.lunaChain;
+}
+
+export function getWorldLineVoyagerData(game: IGame) {
+  game.mingyueData ??= {};
+  game.mingyueData.worldLineVoyager ??= {
+    isOneActionThisRound: false,
+  };
+  return game.mingyueData.worldLineVoyager;
+}

--- a/src/server/mingyue/MingYueExpansion.ts
+++ b/src/server/mingyue/MingYueExpansion.ts
@@ -1,0 +1,19 @@
+import {MingYueData} from './MingYueData';
+
+export class MingYueExpansion {
+  private constructor() {}
+
+  public static initialize(): MingYueData {
+    return {
+      lunaChain: {
+        lastProjectCardMegacreditCost: undefined,
+        totalGain: 0,
+        projectCardCount: 0,
+      },
+      worldLineVoyager: {
+        // 初始为 β 世界线（3 次行动）
+        isOneActionThisRound: false,
+      },
+    };
+  }
+}

--- a/src/server/mingyue/SerializedMingYueData.ts
+++ b/src/server/mingyue/SerializedMingYueData.ts
@@ -1,0 +1,10 @@
+export interface SerializedMingYueData {
+  lunaChain?: {
+    lastProjectCardMegacreditCost?: number;
+    totalGain: number;
+    projectCardCount: number;
+  };
+  worldLineVoyager?: {
+    isOneActionThisRound: boolean;
+  };
+}

--- a/src/server/models/ModelUtils.ts
+++ b/src/server/models/ModelUtils.ts
@@ -51,13 +51,13 @@ export function cardsToModel(
     // 《LunaChain》专用: 记录上一张项目牌的实际支付费用
     let lastProjectCardCost: number | undefined = undefined;
     if (card.name === CardName.LUNA_CHAIN) {
-      lastProjectCardCost = (card as LunaChain).getLastProjectCardMegacreditCost();
+      lastProjectCardCost = (card as LunaChain).getLastProjectCardMegacreditCost(player);
     }
 
     // 《世界线航行者》专用: 记录当前所处世界线状态
     let currentWorldline: number | undefined = undefined;
     if (card.name === CardName.WORLD_LINE_VOYAGER) {
-      currentWorldline = (card as WorldLineVoyager).getCurrentWorldline();
+      currentWorldline = (card as WorldLineVoyager).getCurrentWorldline(player);
     }
 
     const model: CardModel = {

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -700,6 +700,7 @@ describe('Game', () => {
     game.syndicatePirateRaider = undefined;
     game.moonData = undefined;
     game.pathfindersData = undefined;
+    game.mingyueData = undefined;
     const serialized = game.serialize();
     assertIsJSON(serialized);
     const serializedKeys = Object.keys(serialized);


### PR DESCRIPTION
- 在 Game.ts 中新增 mingyueData 字段，并在启用 mingyueExpansion 时初始化
- 实现 mingyueData 的序列化与反序列化逻辑
- 更新 IGame 和 SerializedGame 接口，加入 mingyueData 类型定义
- LunaChain 公司卡牌：将原本存储于实例字段的数据迁移至 mingyueData
- WorldLineVoyager 公司卡牌：使用 mingyueData 中的状态控制行动次数与切换逻辑

此更改统一管理明月扩展的数据结构，提升可维护性与拓展性