### PR TITLE
feat: 支持公司卡（Corporation Card）轮抽，泛型化 Draft 类型并添加相关 UI 配置项

### DIFF
--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -365,6 +365,14 @@
                                 </label>
                                 </div>
 
+                                <div v-if="initialDraft && doubleCorpVariant">
+                                <input type="checkbox" name="corporationDraft" v-model="corporationDraftVariant" id="corporationDraft-checkbox">
+                                <label for="corporationDraft-checkbox">
+                                    <span v-i18n>Corporation Draft variant</span>&nbsp;
+                                    <a href="" class="tooltip" target="_blank">&#9432;</a>
+                                </label>
+                                </div>
+
                                 <div v-if="initialDraft && expansions.prelude">
                                 <input type="checkbox" name="preludeDraft" v-model="preludeDraftVariant" id="preludeDraft-checkbox">
                                 <label for="preludeDraft-checkbox">
@@ -665,6 +673,7 @@ export default (Vue as WithRefs<Refs>).extend({
       customCeos: [],
       startingCeos: 3,
       startingPreludes: 4,
+      corporationDraftVariant: undefined,
       preludeDraftVariant: undefined,
       preludeToggled: false,
       uploading: false,
@@ -1238,6 +1247,7 @@ export default (Vue as WithRefs<Refs>).extend({
         soloTR,
         clonedGamedId,
         initialDraft,
+        corporationDraftVariant: this.corporationDraftVariant ?? false,
         preludeDraftVariant: this.preludeDraftVariant ?? false,
         randomMA,
         shuffleMapOption,

--- a/src/client/components/create/CreateGameModel.ts
+++ b/src/client/components/create/CreateGameModel.ts
@@ -37,6 +37,7 @@ export type CreateGameModel = {
   players: Array<NewPlayerModel>;
   playersCount: number;
   politicalAgendasExtension: AgendaStyle;
+  corporationDraftVariant: boolean | undefined;
   preludeDraftVariant: boolean | undefined;
   randomFirstPlayer: boolean;
   randomMA: RandomMAOptionType;

--- a/src/common/game/NewGameConfig.ts
+++ b/src/common/game/NewGameConfig.ts
@@ -48,6 +48,7 @@ export interface NewGameConfig {
   // Variants
   draftVariant: boolean;
   initialDraft: boolean; // initialDraftVariant: boolean;
+  corporationDraftVariant: boolean;
   preludeDraftVariant: boolean;
   startingCorporations: number;
   shuffleMapOption: boolean;

--- a/src/common/models/GameOptionsModel.ts
+++ b/src/common/models/GameOptionsModel.ts
@@ -20,6 +20,7 @@ export type GameOptionsModel = {
   includedCards: ReadonlyArray<CardName>;
   includeFanMA: boolean,
   initialDraftVariant: boolean,
+  corporationDraftVariant: boolean,
   preludeDraftVariant: boolean,
   politicalAgendasExtension: AgendaStyle,
   removeNegativeGlobalEvents: boolean,

--- a/src/locales/cn/ui.json
+++ b/src/locales/cn/ui.json
@@ -69,6 +69,7 @@
   "Custom Preludes list": "自定义前序卡列表",
   "World Government Terraforming": "世界政府",
   "Draft variant": "轮抽变体",
+  "Corporation Draft variant": "公司轮抽变体",
   "Prelude Draft variant": "前序轮抽变体",
   "Initial Draft variant": "初始轮抽变体",
   "Initial Draft rounds": "初始轮抽轮次",

--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -286,6 +286,7 @@ export class Game implements IGame, Logger {
     if (players.length === 1) {
       gameOptions.draftVariant = false;
       gameOptions.initialDraftVariant = false;
+      gameOptions.corporationDraftVariant = false;
       gameOptions.preludeDraftVariant = false;
       gameOptions.randomMA = RandomMAOptionType.NONE;
 
@@ -379,6 +380,7 @@ export class Game implements IGame, Logger {
         gameOptions.coloniesExtension ||
         gameOptions.turmoilExtension ||
         gameOptions.initialDraftVariant ||
+        gameOptions.corporationDraftVariant ||
         gameOptions.preludeDraftVariant ||
         gameOptions.underworldExpansion ||
         gameOptions.moonExpansion) {

--- a/src/server/IPlayer.ts
+++ b/src/server/IPlayer.ts
@@ -115,6 +115,8 @@ export interface IPlayer {
   draftHand: Array<IProjectCard>;
   /** Cards this player has already chosen during this draft round */
   draftedCards: Array<IProjectCard>;
+  genericDraftHand: Array<ICorporationCard>;
+  genericDraftedCards: Array<ICorporationCard>;
   /** true when this player is drafting, false when player is not, undefined when there is no draft phase. */
   needsToDraft?: boolean;
 

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -212,6 +212,8 @@ export class Player implements IPlayer {
   public playedCards: Array<IProjectCard> = [];
   public draftedCards: Array<IProjectCard> = [];
   public draftHand: Array<IProjectCard> = [];
+  public genericDraftedCards: Array<ICorporationCard> = [];
+  public genericDraftHand: Array<ICorporationCard> = [];
   public cardCost: number = constants.CARD_COST;
   public needsToDraft?: boolean;
 

--- a/src/server/game/GameOptions.ts
+++ b/src/server/game/GameOptions.ts
@@ -41,8 +41,8 @@ export type GameOptions = {
   // Variants
   draftVariant: boolean;
   initialDraftVariant: boolean;
+  corporationDraftVariant: boolean;
   preludeDraftVariant: boolean;
-  // corporationsDraft: boolean;
   startingCorporations: number;
   shuffleMapOption: boolean;
   randomMA: RandomMAOptionType;
@@ -109,6 +109,7 @@ export const DEFAULT_GAME_OPTIONS: GameOptions = {
   moonStandardProjectVariant1: false,
   pathfindersExpansion: false,
   politicalAgendasExtension: AgendaStyle.STANDARD,
+  corporationDraftVariant: false,
   preludeDraftVariant: false,
   preludeExtension: false,
   prelude2Expansion: false,

--- a/src/server/models/ServerModel.ts
+++ b/src/server/models/ServerModel.ts
@@ -448,6 +448,7 @@ export class Server {
       includedCards: options.includedCards,
       includeFanMA: options.includeFanMA,
       initialDraftVariant: options.initialDraftVariant,
+      corporationDraftVariant: options.corporationDraftVariant,
       preludeDraftVariant: options.preludeDraftVariant,
       politicalAgendasExtension: options.politicalAgendasExtension,
       removeNegativeGlobalEvents: options.removeNegativeGlobalEventsOption,

--- a/src/server/routes/ApiCreateGame.ts
+++ b/src/server/routes/ApiCreateGame.ts
@@ -143,6 +143,7 @@ export class ApiCreateGame extends Handler {
             pathfindersExpansion: gameReq.expansions.pathfinders,
             politicalAgendasExtension: gameReq.politicalAgendasExtension,
             prelude2Expansion: gameReq.expansions.prelude2,
+            corporationDraftVariant: gameReq.corporationDraftVariant,
             preludeDraftVariant: gameReq.preludeDraftVariant,
             preludeExtension: gameReq.expansions.prelude,
             promoCardsOption: gameReq.expansions.promo,


### PR DESCRIPTION
- 将 Draft 类型泛型化，支持不同卡牌类型（如 ICorporationCard），并通过 useGeneric 标志区分使用原始字段或泛型字段；

- 原 draft 逻辑仅支持 IProjectCard（包括其子类 IPreludeCard），本次修改将泛型参数放宽为 ICard，并根据类型区分项目卡与公司卡的 draft 流程，以兼容 ICorporationCard 的使用。

- 实现 corporation 类型的轮抽流程，完整支持多轮传牌、卡牌选择与落牌；

- 为 IPlayer 添加泛型字段 genericDraftHand 和 genericDraftedCards，用于存储不同类型轮抽数据；

- 在 CreateGameForm.vue 添加“公司轮抽变体（Corporation Draft variant）”复选框，用于开启公司轮抽功能；

- 扩展 NewGameConfig、CreateGameModel 和 GameOptionsModel，添加用于控制公司轮抽的布尔配置项；

类型继承关系：
ICard
├── IProjectCard
│ └── IPreludeCard
└── ICorporationCard