### PR TITLE
优化：明确狸克建设的板块放置触发条件

### DIFF
--- a/src/locales/cn/mingyue_corporations.json
+++ b/src/locales/cn/mingyue_corporations.json
@@ -53,5 +53,5 @@
   "NOOK CONSTRUCTION": "狸克建设",
   "You start with 50 M€ and 2 Bells.": "起始获得50M€和2个铃钱。",
   "Effect: When you place a special tile on Mars, Gain 1 Bells.": "效果：当你在火星上放置一个特殊板块时，获得1个铃钱。",
-  "Effect: When you place any tile on Mars, Gain 2 + ⌊Bells ÷ 4⌋ M€.": "效果：当你在火星上放置任意板块时，获得 2 + ⌊铃钱 ÷ 4⌋ M€。"
+  "Effect: When you place any tile on Mars (excluding ocean tiles), gain 2 + ⌊Bells ÷ 4⌋ M€.": "效果：当你在火星上放置任意非海洋板块时，获得 2 + ⌊铃钱 ÷ 4⌋ M€。"
 }

--- a/src/locales/cn/mingyue_corporations.json
+++ b/src/locales/cn/mingyue_corporations.json
@@ -37,7 +37,7 @@
   "Infinity Circuit": "无限回路",
   "INFINITY CIRCUIT": "无限回路",
   "You start with 42 M€, and 2 each of plants, energy, and heat.": "起始获得42M€，2 个植物、电力和热能。",
-  "Effect: When you spend 2 or more plants, energy, or heat, gain 2 energy, 2 heat, or 1 plant, respectively.": "效果：当你消耗 2 个或更多的植物、电力或热能时，分别获得 2 个电力、2 个热能或 1 个植物。",
+  "Effect: When you spend 3 or more plants, energy, or heat, gain 2 energy, 2 heat, or 1 plant, respectively.": "效果：当你消耗 3 个或更多的植物、电力或热能时，分别获得 2 个电力、2 个热能或 1 个植物。",
   "${0} gained ${1} energy via ${2} (paid ${3} plants)": "${0} 通过 ${2} 获得了 ${1} 电力（支付了 ${3} 个植物）",
   "${0} gained ${1} heat via ${2} (paid ${3} energy)": "${0} 通过 ${2} 获得了 ${1} 热能（支付了 ${3} 个电力）",
   "${0} gained ${1} plant via ${2} (paid ${3} heat)": "${0} 通过 ${2} 获得了 ${1} 植物（支付了 ${3} 个热能）",

--- a/src/server/cards/mingyue/InfinityCircuit.ts
+++ b/src/server/cards/mingyue/InfinityCircuit.ts
@@ -8,13 +8,13 @@ import {IPlayer} from '../../../server/IPlayer';
 import {Resource} from '../../../common/Resource';
 
 // 无限回路转换比例
-const PLANTS_TO_ENERGY_THRESHOLD = 2;
+const PLANTS_TO_ENERGY_THRESHOLD = 3;
 const PLANTS_TO_ENERGY_GAIN = 2;
 
-const ENERGY_TO_HEAT_THRESHOLD = 2;
+const ENERGY_TO_HEAT_THRESHOLD = 3;
 const ENERGY_TO_HEAT_GAIN = 2;
 
-const HEAT_TO_PLANTS_THRESHOLD = 2;
+const HEAT_TO_PLANTS_THRESHOLD = 3;
 const HEAT_TO_PLANTS_GAIN = 1;
 
 export class InfinityCircuit extends CorporationCard {
@@ -34,13 +34,13 @@ export class InfinityCircuit extends CorporationCard {
           b.corpBox('effect', (cb) => {
             cb.vSpace(Size.MEDIUM);
             cb.effect(undefined, (eb) => {
-              eb.text('2+').plants(1).startEffect.energy(PLANTS_TO_ENERGY_GAIN);
+              eb.text('3+').plants(1).startEffect.energy(PLANTS_TO_ENERGY_GAIN);
             });
             cb.effect(undefined, (eb) => {
-              eb.text('2+').energy(1).startEffect.heat(ENERGY_TO_HEAT_GAIN);
+              eb.text('3+').energy(1).startEffect.heat(ENERGY_TO_HEAT_GAIN);
             });
             cb.effect(`When you spend ${HEAT_TO_PLANTS_THRESHOLD} or more plants, energy, or heat, gain ${PLANTS_TO_ENERGY_GAIN} energy, ${ENERGY_TO_HEAT_GAIN} heat, or ${HEAT_TO_PLANTS_GAIN} plant, respectively.`, (eb) => {
-              eb.text('2+').heat(1).startEffect.plants(HEAT_TO_PLANTS_GAIN);
+              eb.text('3+').heat(1).startEffect.plants(HEAT_TO_PLANTS_GAIN);
             });
           });
         }),

--- a/src/server/cards/mingyue/NookConstruction.ts
+++ b/src/server/cards/mingyue/NookConstruction.ts
@@ -39,7 +39,7 @@ export class NookConstruction extends CorporationCard {
               },
             );
             cb.effect(
-              'When you place any tile on Mars, Gain 2 + ⌊Bells ÷ 4⌋ M€.',
+              'When you place any tile on Mars (excluding ocean tiles), gain 2 + ⌊Bells ÷ 4⌋ M€.',
               (eb) => {
                 eb.emptyTile('normal', {size: Size.SMALL}).asterix().startEffect.megacredits(2).plus().megacredits(1).slash().resource(CardResource.BELLS, {amount: BELLS_TO_MEGACREDIT_RATIO, digit});
               },
@@ -51,21 +51,21 @@ export class NookConstruction extends CorporationCard {
   }
 
   public onTilePlaced(cardOwner: IPlayer, activePlayer: IPlayer, space: Space, boardType: BoardType): void {
-    // 确保是由卡牌所有者放置的板块
+    // 仅在卡牌拥有者亲自放置板块时触发
     if (cardOwner.id !== activePlayer.id) return;
 
-    // 仅限火星板块
+    // 仅适用于火星地图（排除月球等其他地图）
     if (boardType !== BoardType.MARS) return;
 
-    // 确保板块已被玩家占据
+    // 排除无玩家标记的板块（如海洋）
     if (space.player === undefined) return;
 
-    // 跳过殖民地板块
+    // 跳过殖民地类型的板块
     if (space.spaceType === SpaceType.COLONY) return;
 
     const game = cardOwner.game;
 
-    // 放置特殊板块时获得 1 铃钱
+    // 放置特殊板块时获得 1 个铃钱
     if (isSpecialTileSpace(space)) {
       cardOwner.addResourceTo(this, 1);
       game.log(
@@ -74,7 +74,7 @@ export class NookConstruction extends CorporationCard {
       );
     }
 
-    // 任意板块放置都能获得返现（根据铃钱数量）
+    // 放置任意板块可返现，返现金额与铃钱数量有关
     const bellsCount = this.resourceCount;
     const income = Math.floor(bellsCount / BELLS_TO_MEGACREDIT_RATIO) + 2;
 


### PR DESCRIPTION
### 📝 描述

本次 PR 包含以下优化与调整：

- **功能优化**：优化《狸克建设》的技能描述
  
  - 明确了仅由卡牌所有者在**火星地图**上主动放置的、**非海洋且非殖民地板块**才会触发效果
  
  - 注释更加清晰地阐述了触发条件与排除情况，增强了可读性与维护性

- **平衡性调整**：
  
  - 将《无限回路》的触发门槛从“消耗 2 个或更多资源”调整为“消耗 3 个或更多资源”