### PR TITLE
feat: 添加新项目卡牌 MY11 - 月见兔苑（Moonlit Warren）

### DIFF
--- a/src/common/cards/CardName.ts
+++ b/src/common/cards/CardName.ts
@@ -611,6 +611,7 @@ export enum CardName {
   GAMBLING_DISTRICT_LAS_VEGAS = 'Gambling District Las Vegas',
   ARTIFACT_HARVEST = 'Artifact Harvest',
   DIVERGENCIES_ASSORT = 'Divergencies Assort',
+  MOONLIT_WARREN = 'Moonlit Warren',
 
   // MingYue corps
   TRISYN_INSTITUTE = 'Trisyn Institute',

--- a/src/locales/cn/mingyue_cards.json
+++ b/src/locales/cn/mingyue_cards.json
@@ -40,6 +40,18 @@
   "Select 1 card to keep or none": "选择保留 1 张牌或不保留",
   "${0} kept a card during the action of ${1}.": "${0} 在 ${1} 的行动中保留了一张牌",
   "${0} drew a card due to the action of ${1}.": "${0} 因 ${1} 的行动抽了一张牌",
-  "${0} kept no cards during the action of ${1}.": "${0} 在 ${1} 的行动中未保留任何牌"
+  "${0} kept no cards during the action of ${1}.": "${0} 在 ${1} 的行动中未保留任何牌",
+
+  "Moonlit Warren": "月见兔苑",
+  "Action: Spend up to X plants to add that many animals here. X = ⌊animals / 2⌋": "行动：至多消耗X个植物资源，在此牌上添加等量的动物。X = ⌊动物数量 / 2⌋",
+  "1 VP per 2 animals on this card.": "此牌上每有2个动物资源，获得1分。",
+  "Add 2 animals to this card.": "将2个动物资源放置于此牌上。",
+  "Choose how many plants to spend (max: 1)": "选择要消耗的植物数量（最多：1）",
+  "Choose how many plants to spend (max: 2)": "选择要消耗的植物数量（最多：2）",
+  "Choose how many plants to spend (max: 3)": "选择要消耗的植物数量（最多：3）",
+  "Choose how many plants to spend (max: 4)": "选择要消耗的植物数量（最多：4）",
+  "Choose how many plants to spend (max: 5)": "选择要消耗的植物数量（最多：5）",
+  "Feed": "喂食",
+  "${0} spent ${1} plant(s) to add ${2} animal(s) to ${3}.": "${0} 消耗了 ${1} 个植物资源，将 ${2} 个动物放置到 ${3}上。"
 
 }

--- a/src/server/cards/mingyue/MingYueCardManifest.ts
+++ b/src/server/cards/mingyue/MingYueCardManifest.ts
@@ -18,6 +18,7 @@ import {DivergenciesAssort} from './DivergenciesAssort';
 import {InfinityCircuit} from './InfinityCircuit';
 import {HeavyworksCreed} from './HeavyworksCreed';
 import {NookConstruction} from './NookConstruction';
+import {MoonlitWarren} from './MoonlitWarren';
 
 export const MINGYUE_CARD_MANIFEST = new ModuleManifest({
   module: 'mingyue',
@@ -43,6 +44,7 @@ export const MINGYUE_CARD_MANIFEST = new ModuleManifest({
     [CardName.ECOLOGICAL_PAVILION]: {Factory: EcologicalPavilion},
     [CardName.ARTIFACT_HARVEST]: {Factory: ArtifactHarvest},
     [CardName.DIVERGENCIES_ASSORT]: {Factory: DivergenciesAssort},
+    [CardName.MOONLIT_WARREN]: {Factory: MoonlitWarren},
     [CardName.GAMBLING_DISTRICT_LAS_VEGAS]: {Factory: GamblingDistrictLasVegas, compatibility: 'ares'},
   },
   globalEvents: {

--- a/src/server/cards/mingyue/MoonlitWarren.ts
+++ b/src/server/cards/mingyue/MoonlitWarren.ts
@@ -1,0 +1,73 @@
+import {IProjectCard} from '../IProjectCard';
+import {IPlayer} from '../../IPlayer';
+import {Card} from '../Card';
+import {CardType} from '../../../common/cards/CardType';
+import {CardName} from '../../../common/cards/CardName';
+import {CardRenderer} from '../render/CardRenderer';
+import {IActionCard} from '../ICard';
+import {Resource} from '../../../common/Resource';
+import {Tag} from '../../../common/cards/Tag';
+import {CardResource} from '../../../common/CardResource';
+import {SelectAmount} from '../../inputs/SelectAmount';
+import {digit} from '../Options';
+
+export class MoonlitWarren extends Card implements IProjectCard, IActionCard {
+  constructor() {
+    super({
+      type: CardType.ACTIVE,
+      name: CardName.MOONLIT_WARREN,
+      cost: 8,
+      tags: [Tag.MOON, Tag.ANIMAL],
+      resourceType: CardResource.ANIMAL,
+      victoryPoints: {resourcesHere: {}, per: 2},
+
+      behavior: {
+        addResources: 2,
+      },
+
+      metadata: {
+        cardNumber: 'MY11',
+        renderData: CardRenderer.builder((b) => {
+          b.action(
+            'Spend up to X plants to add that many animals here. X = ⌊animals / 2⌋',
+            (eb) => {
+              eb.text('X').plants(1).startAction.text('X').resource(CardResource.ANIMAL);
+            },
+          ).br;
+          b.vpText('1 VP per 2 animals on this card.').br;
+          b.resource(CardResource.ANIMAL, {amount: 2, digit});
+        }),
+        description: 'Add 2 animals to this card.',
+      },
+    });
+  }
+
+  public canAct(player: IPlayer): boolean {
+    const animals = this.resourceCount;
+    const maxSpend = Math.floor(animals / 2);
+    return maxSpend > 0 && player.plants > 0;
+  }
+
+  public action(player: IPlayer) {
+    const animals = this.resourceCount;
+    const maxSpend = Math.min(Math.floor(animals / 2), player.plants);
+
+    return new SelectAmount(
+      `Choose how many plants to spend (max: ${maxSpend})`,
+      'Feed',
+      1,
+      maxSpend,
+      true,
+    ).andThen((amount) => {
+      if (amount > 0) {
+        player.stock.deduct(Resource.PLANTS, amount);
+        player.addResourceTo(this, amount);
+        player.game.log(
+          '${0} spent ${1} plant(s) to add ${2} animal(s) to ${3}.',
+          (b) => b.player(player).number(amount).number(amount).card(this),
+        );
+      }
+      return undefined;
+    });
+  }
+}


### PR DESCRIPTION
- 类型：主动项目卡，费用8，动物标志
- 效果：打出时获得2只动物
- 行动：消耗至多X个植物来添加等量动物（X = 本卡上动物数量的一半，向下取整）
- 每2只动物提供1胜利点
- 添加了相关的日志文本和UI翻译字符串