### PR TITLE
fix: 为 Interplanetary Cinematics Rebalanced 添加初始资源配置

### DIFF
--- a/src/server/cards/rebalanced/InterplanetaryCinematicsRebalanced.ts
+++ b/src/server/cards/rebalanced/InterplanetaryCinematicsRebalanced.ts
@@ -16,7 +16,9 @@ export class InterplanetaryCinematicsRebalanced extends InterplanetaryCinematics
       name: CardName.INTERPLANETARY_CINEMATICS_REBALANCED,
       tags: [],
       startingMegaCredits: 60,
-      behavior: undefined,
+      behavior: {
+        stock: {steel: 0},
+      },
       metadata: {
         cardNumber: 'RB-CORP-02',
         description: 'You start with 60 M€.',


### PR DESCRIPTION
- 在重平衡版本的 Interplanetary Cinematics 公司中加入初始资源配置：stock.steel = 0；
- 保持其原有的60 M€起始资金不变；