### PR TITLE
fix: 调整行动阶段判断逻辑以支持世界线航行者，移除对 solo 模式的特殊处理

### DIFF
--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -1590,11 +1590,13 @@ export class Player implements IPlayer {
         this.availableActionsThisRound = getWorldLineVoyagerData(this.game).isOneActionThisRound ? 1 : 3;
       }
 
-      if (game.hasPassedThisActionPhase(this) ||
-        (
-          this.allOtherPlayersHavePassed() === false &&
-          this.actionsTakenThisRound >= this.availableActionsThisRound
-        )
+      const reachedActionLimit = this.actionsTakenThisRound >= this.availableActionsThisRound;
+      if (
+        game.hasPassedThisActionPhase(this) ||
+        (reachedActionLimit && (
+          worldlinevoyager instanceof WorldLineVoyager ||
+          this.allOtherPlayersHavePassed() === false
+        ))
       ) {
         // 如果玩家拥有世界线航行者公司，则行动次数在1次、3次切换
         if (worldlinevoyager instanceof WorldLineVoyager) {
@@ -1801,10 +1803,6 @@ export class Player implements IPlayer {
 
   private allOtherPlayersHavePassed(): boolean {
     const game = this.game;
-    // 如果玩家拥有世界线航行者公司，则solo模式也需要进行回合切换，确保世界线能够切换
-    // MingYueTUDO: 暂未发现世界线航行者公司在solo模式下是否存在bug
-    const worldlinevoyager = this.getCorporation(CardName.WORLD_LINE_VOYAGER);
-    if (game.isSoloMode() && worldlinevoyager instanceof WorldLineVoyager) return false;
     if (game.isSoloMode()) return true;
     const players = game.getPlayers();
     const passedPlayers = game.getPassedPlayers();


### PR DESCRIPTION
- 原逻辑中，当为 solo 模式或多人模式下其他玩家均跳过时，当前玩家无需刷新行动次数（默认可无限行动）
- 为支持世界线航行者公司在此情况下正确限制行动次数，调整了判断逻辑：
  - 合并 reachedActionLimit、是否为世界线航行者、其他玩家是否跳过 的判断条件
  - 使得在上述情况下，依然能够刷新行动次数以实现世界线切换机制
- 移除 allOtherPlayersHavePassed 中已废弃的 solo 模式世界线航行者特殊判断
- 提取 reachedActionLimit 变量，提升可读性与维护性