### PR TITLE
feat: 添加公司卡牌 RB-CORP-07 与 RB-CORP-08 的重制版本

### DIFF
--- a/src/client/components/card/CardCorporationLogo.vue
+++ b/src/client/components/card/CardCorporationLogo.vue
@@ -134,7 +134,7 @@
         <span style="color: rgb(208, 96, 3);box-shadow: -6px -6px #d58c56;">MATHS</span>
       </div>
     </template>
-    <template v-else-if="title === CardName.TYCHO_MAGNETICS">
+    <template v-else-if="title === CardName.TYCHO_MAGNETICS || title === CardName.TYCHO_MAGNETICS_REBALANCED">
       <div class="card-tycho-magnetics-logo">
         <div>TYCHO</div>
         <div>MAGNETICS</div>

--- a/src/client/components/card/CardCorporationLogo.vue
+++ b/src/client/components/card/CardCorporationLogo.vue
@@ -217,6 +217,7 @@ const imageLogosWithNames: Map<CardName, string> = new Map([
   [CardName.POSEIDON, 'card-poseidon-logo'],
   [CardName.MORNING_STAR_INC, 'card-morning-star-logo'],
   [CardName.PRISTAR, 'card-pristar-logo'],
+  [CardName.PRISTAR_REBALANCED, 'card-pristar-logo'],
   [CardName.CREDICOR, 'card-credicor-logo'],
   [CardName.ECOLINE, 'card-ecoline-logo'],
   [CardName.HELION, 'card-helion-logo'],

--- a/src/common/cards/CardName.ts
+++ b/src/common/cards/CardName.ts
@@ -645,6 +645,7 @@ export enum CardName {
   CELESTIC_REBALANCED = 'Celestic Rebalanced',
   SOLBANK_REBALANCED = 'SolBank Rebalanced',
   ODYSSEY_REBALANCED = 'Odyssey Rebalanced',
+  TYCHO_MAGNETICS_REBALANCED = 'Tycho Magnetics Rebalanced',
 
   // Rebalanced preludes
 

--- a/src/common/cards/CardName.ts
+++ b/src/common/cards/CardName.ts
@@ -646,6 +646,7 @@ export enum CardName {
   SOLBANK_REBALANCED = 'SolBank Rebalanced',
   ODYSSEY_REBALANCED = 'Odyssey Rebalanced',
   TYCHO_MAGNETICS_REBALANCED = 'Tycho Magnetics Rebalanced',
+  PRISTAR_REBALANCED = 'Pristar Rebalanced',
 
   // Rebalanced preludes
 

--- a/src/locales/cn/rebalanced_corporations.json
+++ b/src/locales/cn/rebalanced_corporations.json
@@ -40,5 +40,13 @@
   "ODYSSEY_REBALANCED": "ODYSSEY",
   "Odyssey Rebalanced": "Odyssey",
   "ODYSSEY REBALANCED": "ODYSSEY",
-  "Action: Play for free an event card you have already played that has a base cost of 16M€ or less (INCLUDING events that place special tiles,) after which discard that card.": "行动：你可以免费再次打出一张已打出的事件卡（费用至多为16M€，包括放置特殊板块的事件卡），然后丢弃这张事件卡。"
+  "Action: Play for free an event card you have already played that has a base cost of 16M€ or less (INCLUDING events that place special tiles,) after which discard that card.": "行动：你可以免费再次打出一张已打出的事件卡（费用至多为16M€，包括放置特殊板块的事件卡），然后丢弃这张事件卡。",
+
+  "Tycho_Magnetics_Rebalanced": "Tycho_Magnetics",
+  "TYCHO_MAGNETICS_REBALANCED": "TYCHO_MAGNETICS",
+  "Tycho Magnetics Rebalanced": "Tycho Magnetics",
+  "TYCHO MAGNETICS REBALANCED": "TYCHO MAGNETICS",
+  "You start with 42 M€, 1 energy and 1 energy production.": "起始获得42 M€，1点电力和1点电力产能。",
+  "Action: Spend any amount of energy to draw that many cards. Keep 1 and discard the rest. (For every additional 5 energy spent, excluding the first, you may keep 1 more.)": "行动：消耗任意数量的电力来抽取等量的卡牌，保留1张并弃置其余。（每额外消耗5点电力，不计首点，可额外保留1张。）"
+
 }

--- a/src/locales/cn/rebalanced_corporations.json
+++ b/src/locales/cn/rebalanced_corporations.json
@@ -47,6 +47,12 @@
   "Tycho Magnetics Rebalanced": "Tycho Magnetics",
   "TYCHO MAGNETICS REBALANCED": "TYCHO MAGNETICS",
   "You start with 42 M€, 1 energy and 1 energy production.": "起始获得42 M€，1点电力和1点电力产能。",
-  "Action: Spend any amount of energy to draw that many cards. Keep 1 and discard the rest. (For every additional 5 energy spent, excluding the first, you may keep 1 more.)": "行动：消耗任意数量的电力来抽取等量的卡牌，保留1张并弃置其余。（每额外消耗5点电力，不计首点，可额外保留1张。）"
+  "Action: Spend any amount of energy to draw that many cards. Keep 1 and discard the rest. (For every additional 5 energy spent, excluding the first, you may keep 1 more.)": "行动：消耗任意数量的电力来抽取等量的卡牌，保留1张并弃置其余。（每额外消耗5点电力，不计首点，可额外保留1张。）",
+
+  "Pristar_Rebalanced": "Pristar",
+  "PRISTAR_REBALANCED": "PRISTAR",
+  "Pristar Rebalanced": "Pristar",
+  "PRISTAR REBALANCED": "PRISTAR",
+  "Effect: During production phase, if you did not get TR so far this generation, or if you have the lowest TR, add one preservation resource here and gain 6 M€.": "效果：在生产阶段，若你本时代未提升改造度，或改造度为全场最低，获得6M€并添加1个卫资源。"
 
 }

--- a/src/locales/cn/turmoil_corporations.json
+++ b/src/locales/cn/turmoil_corporations.json
@@ -23,6 +23,6 @@
 
   "Pristar": "星际预防所",
   "PRISTAR": "星际预防所",
-  "You start with 53 M€. Decrease your TR 2 steps. 1 VP per preservation resource here.": "起始获得53 M€,降低你的改造度(TR)2级这张牌上每有1个保卫资源,获得1分",
-  "Effect: During production phase, if you did not get TR so far this generation, add one preservation resource here and gain 6 M€.": "效果： 生产阶段时,如果你本时代没提升过改造度,则放置1个保卫资源到这张牌并获得6 M€"
+  "You start with 53 M€. Decrease your TR 2 steps. 1 VP per preservation resource here.": "起始获得53 M€，降低你的改造度(TR)2级。这张牌上每有1个卫资源，获得1分",
+  "Effect: During production phase, if you did not get TR so far this generation, add one preservation resource here and gain 6 M€.": "效果：在生产阶段，若你本时代未提升改造度，获得6M€并添加1个卫资源。"
 }

--- a/src/server/cards/promo/TychoMagnetics.ts
+++ b/src/server/cards/promo/TychoMagnetics.ts
@@ -7,28 +7,33 @@ import {IPlayer} from '../../IPlayer';
 import {SelectAmount} from '../../inputs/SelectAmount';
 
 export class TychoMagnetics extends CorporationCard {
-  constructor() {
+  constructor({
+    name = CardName.TYCHO_MAGNETICS,
+    behavior = {
+      stock: {energy: 0},
+      production: {energy: 1},
+    },
+    metadata = {
+      cardNumber: 'XC02', // Rename
+      description: 'You start with 42 M€. Increase your energy production 1 step.',
+      renderData: CardRenderer.builder((b) => {
+        b.br.br;
+        b.production((pb) => pb.energy(1)).nbsp.megacredits(42);
+        b.corpBox('action', (cb) => {
+          cb.action('Spend any amount of energy to draw the that many cards. Keep 1 and discard the rest.', (ab) => {
+            ab.text('X').energy(1).startAction.text('X').cards(1).text('KEEP 1');
+          });
+        });
+      }),
+    },
+  } = {}) {
     super({
-      name: CardName.TYCHO_MAGNETICS,
+      name,
       tags: [Tag.POWER, Tag.SCIENCE],
       startingMegaCredits: 42,
-      behavior: {
-        production: {energy: 1},
-      },
+      behavior,
 
-      metadata: {
-        cardNumber: 'XC02', // Rename
-        description: 'You start with 42 M€. Increase your energy production 1 step.',
-        renderData: CardRenderer.builder((b) => {
-          b.br.br;
-          b.production((pb) => pb.energy(1)).nbsp.megacredits(42);
-          b.corpBox('action', (cb) => {
-            cb.action('Spend any amount of energy to draw the that many cards. Keep 1 and discard the rest.', (ab) => {
-              ab.text('X').energy(1).startAction.text('X').cards(1).text('KEEP 1');
-            });
-          });
-        }),
-      },
+      metadata,
     });
   }
 

--- a/src/server/cards/rebalanced/PristarRebalanced.ts
+++ b/src/server/cards/rebalanced/PristarRebalanced.ts
@@ -1,0 +1,41 @@
+import {IPlayer} from '../../IPlayer';
+import {CardResource} from '../../../common/CardResource';
+import {CardName} from '../../../common/cards/CardName';
+import {CardRenderer} from '../render/CardRenderer';
+import {Size} from '../../../common/cards/render/Size';
+import {Resource} from '../../../common/Resource';
+import {Pristar} from '../turmoil/Pristar';
+
+export class PristarRebalanced extends Pristar {
+  constructor() {
+    super({
+      name: CardName.PRISTAR_REBALANCED,
+
+      metadata: {
+        cardNumber: 'RB-CORP-08',
+        description: 'You start with 53 M€. Decrease your TR 2 steps. 1 VP per preservation resource here.',
+
+        renderData: CardRenderer.builder((b) => {
+          b.br.br.br;
+          b.megacredits(53).minus().tr(2, {size: Size.SMALL});
+          b.corpBox('effect', (ce) => {
+            ce.effect('During production phase, if you did not get TR so far this generation, or if you have the lowest TR, add one preservation resource here and gain 6 M€.', (eb) => {
+              eb.tr(1, {size: Size.SMALL, cancelled: true}).asterix().startEffect.resource(CardResource.PRESERVATION).megacredits(6);
+            });
+          });
+        }),
+      },
+    });
+  }
+
+  public override onProductionPhase(player: IPlayer) {
+    const playerTR = player.getTerraformRating();
+    const isLowestTR = player.getOpponents().every((op) => op.getTerraformRating() > playerTR);
+
+    if (!player.hasIncreasedTerraformRatingThisGeneration || isLowestTR) {
+      player.stock.add(Resource.MEGACREDITS, 6, {log: true, from: this});
+      player.addResourceTo(this, 1);
+    }
+    return undefined;
+  }
+}

--- a/src/server/cards/rebalanced/RebalancedCardManifest.ts
+++ b/src/server/cards/rebalanced/RebalancedCardManifest.ts
@@ -4,6 +4,7 @@ import {ArklightRebalanced} from './ArklightRebalanced';
 import {CelesticRebalanced} from './CelesticRebalanced';
 import {InterplanetaryCinematicsRebalanced} from './InterplanetaryCinematicsRebalanced';
 import {OdysseyRebalanced} from './OdysseyRebalanced';
+import {PristarRebalanced} from './PristarRebalanced';
 import {SolBankRebalanced} from './SolBankRebalanced';
 import {ThorgateRebalanced} from './ThorgateRebalanced';
 import {TychoMagneticsRebalanced} from './TychoMagneticsRebalanced';
@@ -18,6 +19,7 @@ export const REBALANCED_CARD_MANIFEST = new ModuleManifest({
     [CardName.SOLBANK_REBALANCED]: {Factory: SolBankRebalanced},
     [CardName.ODYSSEY_REBALANCED]: {Factory: OdysseyRebalanced},
     [CardName.TYCHO_MAGNETICS_REBALANCED]: {Factory: TychoMagneticsRebalanced},
+    [CardName.PRISTAR_REBALANCED]: {Factory: PristarRebalanced},
   },
   preludeCards: {
   },
@@ -33,5 +35,6 @@ export const REBALANCED_CARD_MANIFEST = new ModuleManifest({
     CardName.SOLBANK,
     CardName.ODYSSEY,
     CardName.TYCHO_MAGNETICS,
+    CardName.PRISTAR,
   ],
 });

--- a/src/server/cards/rebalanced/RebalancedCardManifest.ts
+++ b/src/server/cards/rebalanced/RebalancedCardManifest.ts
@@ -6,6 +6,7 @@ import {InterplanetaryCinematicsRebalanced} from './InterplanetaryCinematicsReba
 import {OdysseyRebalanced} from './OdysseyRebalanced';
 import {SolBankRebalanced} from './SolBankRebalanced';
 import {ThorgateRebalanced} from './ThorgateRebalanced';
+import {TychoMagneticsRebalanced} from './TychoMagneticsRebalanced';
 
 export const REBALANCED_CARD_MANIFEST = new ModuleManifest({
   module: 'rebalanced',
@@ -16,6 +17,7 @@ export const REBALANCED_CARD_MANIFEST = new ModuleManifest({
     [CardName.CELESTIC_REBALANCED]: {Factory: CelesticRebalanced},
     [CardName.SOLBANK_REBALANCED]: {Factory: SolBankRebalanced},
     [CardName.ODYSSEY_REBALANCED]: {Factory: OdysseyRebalanced},
+    [CardName.TYCHO_MAGNETICS_REBALANCED]: {Factory: TychoMagneticsRebalanced},
   },
   preludeCards: {
   },
@@ -30,5 +32,6 @@ export const REBALANCED_CARD_MANIFEST = new ModuleManifest({
     CardName.CELESTIC,
     CardName.SOLBANK,
     CardName.ODYSSEY,
+    CardName.TYCHO_MAGNETICS,
   ],
 });

--- a/src/server/cards/rebalanced/TychoMagneticsRebalanced.ts
+++ b/src/server/cards/rebalanced/TychoMagneticsRebalanced.ts
@@ -1,0 +1,55 @@
+import {CardName} from '../../../common/cards/CardName';
+import {CardRenderer} from '../render/CardRenderer';
+import {Resource} from '../../../common/Resource';
+import {IPlayer} from '../../IPlayer';
+import {SelectAmount} from '../../inputs/SelectAmount';
+import {TychoMagnetics} from '../promo/TychoMagnetics';
+import {Size} from '../../../common/cards/render/Size';
+
+const ENERGY_PER_EXTRA_KEEP = 5;
+
+export class TychoMagneticsRebalanced extends TychoMagnetics {
+  constructor() {
+    super({
+      name: CardName.TYCHO_MAGNETICS_REBALANCED,
+      behavior: {
+        stock: {energy: 1},
+        production: {energy: 1},
+      },
+
+      metadata: {
+        cardNumber: 'RB-CORP-07',
+        description: 'You start with 42 M€, 1 energy and 1 energy production.',
+        renderData: CardRenderer.builder((b) => {
+          b.br.br;
+          b.megacredits(42).energy(1).production((pb) => pb.energy(1));
+          b.corpBox('action', (cb) => {
+            cb.vSpace(Size.LARGE);
+            cb.action(
+              'Spend any amount of energy to draw that many cards. Keep 1 and discard the rest. (For every additional ' +
+              ENERGY_PER_EXTRA_KEEP +
+              ' energy spent, excluding the first, you may keep 1 more.)', (ab) => {
+                ab.text('X').energy(1).startAction.text('X').cards(1).text('KEEP 1 +<br>⌊(X - 1) ÷ 5⌋', Size.SMALL, true);
+              });
+          });
+        }),
+      },
+    });
+  }
+
+  public override action(player: IPlayer) {
+    const max = Math.min(player.energy, player.game.projectDeck.size());
+    return new SelectAmount('Select amount of energy to spend', 'OK', 1, max)
+      .andThen((amount) => {
+        player.stock.deduct(Resource.ENERGY, amount);
+        player.game.log('${0} spent ${1} energy', (b) => b.player(player).number(amount));
+        if (amount === 1) {
+          player.drawCard();
+          return undefined;
+        }
+        const keepCount = 1 + Math.floor((amount - 1) / ENERGY_PER_EXTRA_KEEP);
+        player.drawCardKeepSome(amount, {keepMax: keepCount});
+        return undefined;
+      });
+  }
+}

--- a/src/server/cards/turmoil/Pristar.ts
+++ b/src/server/cards/turmoil/Pristar.ts
@@ -7,9 +7,25 @@ import {Size} from '../../../common/cards/render/Size';
 import {Resource} from '../../../common/Resource';
 
 export class Pristar extends CorporationCard {
-  constructor() {
+  constructor({
+    name = CardName.PRISTAR,
+    metadata = {
+      cardNumber: 'R07',
+      description: 'You start with 53 M€. Decrease your TR 2 steps. 1 VP per preservation resource here.',
+
+      renderData: CardRenderer.builder((b) => {
+        b.br.br.br;
+        b.megacredits(53).nbsp.nbsp.minus().tr(2, {size: Size.SMALL});
+        b.corpBox('effect', (ce) => {
+          ce.effect('During production phase, if you did not get TR so far this generation, add one preservation resource here and gain 6 M€.', (eb) => {
+            eb.tr(1, {size: Size.SMALL, cancelled: true}).startEffect.resource(CardResource.PRESERVATION).megacredits(6);
+          });
+        });
+      }),
+    },
+  } = {}) {
     super({
-      name: CardName.PRISTAR,
+      name,
       startingMegaCredits: 53,
       resourceType: CardResource.PRESERVATION,
 
@@ -19,20 +35,7 @@ export class Pristar extends CorporationCard {
         tr: -2,
       },
 
-      metadata: {
-        cardNumber: 'R07',
-        description: 'You start with 53 M€. Decrease your TR 2 steps. 1 VP per preservation resource here.',
-
-        renderData: CardRenderer.builder((b) => {
-          b.br.br.br;
-          b.megacredits(53).nbsp.nbsp.minus().tr(2, {size: Size.SMALL});
-          b.corpBox('effect', (ce) => {
-            ce.effect('During production phase, if you did not get TR so far this generation, add one preservation resource here and gain 6 M€.', (eb) => {
-              eb.tr(1, {size: Size.SMALL, cancelled: true}).startEffect.resource(CardResource.PRESERVATION).megacredits(6);
-            });
-          });
-        }),
-      },
+      metadata,
     });
   }
 


### PR DESCRIPTION
本次 PR 添加了两张重制公司卡牌：

---

### ♻️ RB-CORP-07 - Tycho Magnetics Rebalanced

- 基于原版公司 Tycho Magnetics 进行重制，改动内容如下：

#### 🔧 卡牌效果改动
- 原效果为：消耗任意电力抽等量卡牌，保留 1 张，其余弃置  
- 新效果为：仍消耗等量电力抽牌，保留 1 张，其余弃置（每额外消耗 5 点电力，不计首点，可额外保留 1 张）

---

### ♻️ RB-CORP-08 - Pristar Rebalanced

- 基于原版公司 Pristar 进行重制，改动内容如下：

#### 🔧 卡牌效果改动
- 原效果为：若本时代未提升改造度，生产阶段获得 6 M€ 并添加 1 个卫资源  
- 新效果为：若本时代未提升改造度，**或当前改造度为全场最低**，生产阶段获得 6 M€ 并添加 1 个卫资源
