### PR TITLE
feat: 添加公司卡牌 RB-CORP-09 - Adhai High Orbit Constructions Rebalanced

### DIFF
--- a/src/client/components/card/CardCorporationLogo.vue
+++ b/src/client/components/card/CardCorporationLogo.vue
@@ -200,6 +200,7 @@ const imageOnlyLogos: Map<CardName, string> = new Map([
   [CardName.BIO_SOL, 'card-bio-sol-logo'],
   [CardName.MIND_SET_MARS, 'card-mind-set-mars-logo'],
   [CardName.ADHAI_HIGH_ORBIT_CONSTRUCTIONS, 'card-adhai-high-orbit-constructions-logo'],
+  [CardName.ADHAI_HIGH_ORBIT_CONSTRUCTIONS_REBALANCED, 'card-adhai-high-orbit-constructions-logo'],
   [CardName.HABITAT_MARTE, 'card-habitat-marte-logo'],
   [CardName.ODYSSEY, 'card-odyssey-logo'],
   [CardName.ODYSSEY_REBALANCED, 'card-odyssey-logo'],

--- a/src/common/cards/CardName.ts
+++ b/src/common/cards/CardName.ts
@@ -647,6 +647,7 @@ export enum CardName {
   ODYSSEY_REBALANCED = 'Odyssey Rebalanced',
   TYCHO_MAGNETICS_REBALANCED = 'Tycho Magnetics Rebalanced',
   PRISTAR_REBALANCED = 'Pristar Rebalanced',
+  ADHAI_HIGH_ORBIT_CONSTRUCTIONS_REBALANCED = 'Adhai High Orbit Constructions Rebalanced',
 
   // Rebalanced preludes
 

--- a/src/locales/cn/rebalanced_corporations.json
+++ b/src/locales/cn/rebalanced_corporations.json
@@ -53,6 +53,13 @@
   "PRISTAR_REBALANCED": "PRISTAR",
   "Pristar Rebalanced": "Pristar",
   "PRISTAR REBALANCED": "PRISTAR",
-  "Effect: During production phase, if you did not get TR so far this generation, or if you have the lowest TR, add one preservation resource here and gain 6 M€.": "效果：在生产阶段，若你本时代未提升改造度，或改造度为全场最低，获得6M€并添加1个卫资源。"
+  "Effect: During production phase, if you did not get TR so far this generation, or if you have the lowest TR, add one preservation resource here and gain 6 M€.": "效果：在生产阶段，若你本时代未提升改造度，或改造度为全场最低，获得6M€并添加1个卫资源。",
+
+  "Adhai_High_Orbit_Constructions_Rebalanced": "Adhai High Orbit Constructions",
+  "ADHAI_HIGH_ORBIT_CONSTRUCTIONS_REBALANCED": "ADHAI HIGH ORBIT CONSTRUCTIONS",
+  "Adhai High Orbit Constructions Rebalanced": "Adhai High Orbit Constructions",
+  "ADHAI HIGH ORBIT CONSTRUCTIONS REBALANCED": "ADHAI HIGH ORBIT CONSTRUCTIONS",
+  "Effect: Whenever you play a card with a space tag (including this) add 1 orbital on this card.": "效果：当你打出一张太空牌（包括此牌）时，在此牌上增加1个轨道资源。",
+  "Effect: For every 2 orbitals on this card, cards with a space tag or the STANDARD COLONY PROJECT or TRADE ACTION costs 1M€ less.": "效果：当你打出一张太空牌、或使用殖民地标准项目、或进行贸易时，此卡上每有2个轨道资源，你可以少支付1M€。"
 
 }

--- a/src/server/cards/pathfinders/AdhaiHighOrbitConstructions.ts
+++ b/src/server/cards/pathfinders/AdhaiHighOrbitConstructions.ts
@@ -11,9 +11,25 @@ import {AltSecondaryTag} from '../../../common/cards/render/AltSecondaryTag';
 import {IStandardProjectCard} from '../IStandardProjectCard';
 
 export class AdhaiHighOrbitConstructions extends CorporationCard {
-  constructor() {
+  constructor({
+    name = CardName.ADHAI_HIGH_ORBIT_CONSTRUCTIONS,
+    metadata = {
+      cardNumber: 'PfC23',
+      description: 'You start with 43 M€.',
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(43).nbsp.nbsp.tag(Tag.SPACE, {secondaryTag: AltSecondaryTag.NO_PLANETARY_TAG}).colon().resource(CardResource.ORBITAL).br;
+        b.text('(Effect: Whenever you play a card with a space tag BUT NO PLANETARY TAG (including this) add 1 orbital on this card.)', Size.SMALL, false, false);
+        b.br;
+        b.effect('For every 2 orbitals on this card, cards with a space tag but with no planetary tag or the STANDARD COLONY PROJECT or TRADE ACTION costs 1M€ less.', (eb) => {
+          eb.tag(Tag.SPACE, {secondaryTag: AltSecondaryTag.NO_PLANETARY_TAG}).slash(Size.SMALL).asterix().colonies(1, {size: Size.SMALL}).slash(Size.SMALL).trade({size: Size.SMALL})
+            .startEffect
+            .minus().megacredits(1).text('/2').resource(CardResource.ORBITAL);
+        });
+      }),
+    },
+  } = {}) {
     super({
-      name: CardName.ADHAI_HIGH_ORBIT_CONSTRUCTIONS,
+      name,
       tags: [Tag.SPACE],
       startingMegaCredits: 43,
       resourceType: CardResource.ORBITAL,
@@ -23,23 +39,9 @@ export class AdhaiHighOrbitConstructions extends CorporationCard {
         addResources: 1,
       },
 
-      metadata: {
-        cardNumber: 'PfC23',
-        description: 'You start with 43 M€.',
-        renderData: CardRenderer.builder((b) => {
-          b.megacredits(43).nbsp.nbsp.tag(Tag.SPACE, {secondaryTag: AltSecondaryTag.NO_PLANETARY_TAG}).colon().resource(CardResource.ORBITAL).br;
-          b.text('(Effect: Whenever you play a card with a space tag BUT NO PLANETARY TAG (including this) add 1 orbital on this card.)', Size.SMALL, false, false);
-          b.br;
-          b.effect('For every 2 orbitals on this card, cards with a space tag but with no planetary tag or the STANDARD COLONY PROJECT or TRADE ACTION costs 1M€ less.', (eb) => {
-            eb.tag(Tag.SPACE, {secondaryTag: AltSecondaryTag.NO_PLANETARY_TAG}).slash(Size.SMALL).asterix().colonies(1, {size: Size.SMALL}).slash(Size.SMALL).trade({size: Size.SMALL})
-              .startEffect
-              .minus().megacredits(1).text('/2').resource(CardResource.ORBITAL);
-          });
-        }),
-      },
+      metadata,
     });
   }
-
 
   private matchingTags(tags: Array<Tag>): boolean {
     let spaceTag = false;

--- a/src/server/cards/rebalanced/AdhaiHighOrbitConstructionsRebalanced.ts
+++ b/src/server/cards/rebalanced/AdhaiHighOrbitConstructionsRebalanced.ts
@@ -1,0 +1,49 @@
+import {Tag} from '../../../common/cards/Tag';
+import {IPlayer} from '../../IPlayer';
+import {CardName} from '../../../common/cards/CardName';
+import {CardRenderer} from '../render/CardRenderer';
+import {CardResource} from '../../../common/CardResource';
+import {IProjectCard} from '../IProjectCard';
+import {Size} from '../../../common/cards/render/Size';
+import {AdhaiHighOrbitConstructions} from '../pathfinders/AdhaiHighOrbitConstructions';
+
+export class AdhaiHighOrbitConstructionsRebalanced extends AdhaiHighOrbitConstructions {
+  constructor() {
+    super({
+      name: CardName.ADHAI_HIGH_ORBIT_CONSTRUCTIONS_REBALANCED,
+
+      metadata: {
+        cardNumber: 'RB-CORP-09',
+        description: 'You start with 43 M€.',
+        renderData: CardRenderer.builder((b) => {
+          b.megacredits(43);
+          b.corpBox('effect', (ce) => {
+            ce.vSpace(Size.LARGE);
+            ce.effect('Whenever you play a card with a space tag (including this) add 1 orbital on this card.', (eb) => {
+              eb.tag(Tag.SPACE).startEffect.resource(CardResource.ORBITAL);
+            });
+            ce.effect('For every 2 orbitals on this card, cards with a space tag or the STANDARD COLONY PROJECT or TRADE ACTION costs 1M€ less.', (eb) => {
+              eb.tag(Tag.SPACE).slash().colonies(1, {size: Size.SMALL}).slash().trade({size: Size.SMALL})
+                .startEffect
+                .megacreditsText('-1').slash().text('2').resource(CardResource.ORBITAL);
+            });
+          });
+        }),
+      },
+    });
+  }
+
+  public override onCardPlayed(player: IPlayer, card: IProjectCard) {
+    if (player.isCorporation(CardName.ADHAI_HIGH_ORBIT_CONSTRUCTIONS_REBALANCED) && card.tags.includes(Tag.SPACE)) {
+      player.addResourceTo(this, {qty: 1, log: true});
+    }
+  }
+
+  public override getCardDiscount(player: IPlayer, card: IProjectCard) {
+    if (player.isCorporation(CardName.ADHAI_HIGH_ORBIT_CONSTRUCTIONS_REBALANCED) && card.tags.includes(Tag.SPACE)) {
+      return Math.floor(this.resourceCount / 2);
+    } else {
+      return 0;
+    }
+  }
+}

--- a/src/server/cards/rebalanced/RebalancedCardManifest.ts
+++ b/src/server/cards/rebalanced/RebalancedCardManifest.ts
@@ -1,5 +1,6 @@
 import {CardName} from '../../../common/cards/CardName';
 import {ModuleManifest} from '../ModuleManifest';
+import {AdhaiHighOrbitConstructionsRebalanced} from './AdhaiHighOrbitConstructionsRebalanced';
 import {ArklightRebalanced} from './ArklightRebalanced';
 import {CelesticRebalanced} from './CelesticRebalanced';
 import {InterplanetaryCinematicsRebalanced} from './InterplanetaryCinematicsRebalanced';
@@ -20,6 +21,7 @@ export const REBALANCED_CARD_MANIFEST = new ModuleManifest({
     [CardName.ODYSSEY_REBALANCED]: {Factory: OdysseyRebalanced},
     [CardName.TYCHO_MAGNETICS_REBALANCED]: {Factory: TychoMagneticsRebalanced},
     [CardName.PRISTAR_REBALANCED]: {Factory: PristarRebalanced},
+    [CardName.ADHAI_HIGH_ORBIT_CONSTRUCTIONS_REBALANCED]: {Factory: AdhaiHighOrbitConstructionsRebalanced},
   },
   preludeCards: {
   },
@@ -36,5 +38,6 @@ export const REBALANCED_CARD_MANIFEST = new ModuleManifest({
     CardName.ODYSSEY,
     CardName.TYCHO_MAGNETICS,
     CardName.PRISTAR,
+    CardName.ADHAI_HIGH_ORBIT_CONSTRUCTIONS,
   ],
 });

--- a/src/server/player/Colonies.ts
+++ b/src/server/player/Colonies.ts
@@ -219,7 +219,8 @@ export class TradeWithMegacredits implements IColonyTrader {
 
   constructor(private player: IPlayer) {
     this.tradeCost = MC_TRADE_COST- player.colonies.tradeDiscount;
-    const adhai = player.getCorporation(CardName.ADHAI_HIGH_ORBIT_CONSTRUCTIONS);
+    const adhai = player.getCorporation(CardName.ADHAI_HIGH_ORBIT_CONSTRUCTIONS) ||
+      player.getCorporation(CardName.ADHAI_HIGH_ORBIT_CONSTRUCTIONS_REBALANCED);
     if (adhai !== undefined) {
       const adhaiDiscount = Math.floor(adhai.resourceCount / 2);
       this.tradeCost = Math.max(0, this.tradeCost - adhaiDiscount);


### PR DESCRIPTION
基于原版公司 Adhai High Orbit Constructions 进行重制，改动内容如下：

- 卡牌效果不变，但支持新的平衡数值和公司构造逻辑扩展
  - 轨道资源：每打出一张太空牌（包括此牌），获得 1 个轨道资源
  - 费用减免：每 2 个轨道资源，使带有太空标记的卡牌、使用“殖民地”标准项目、或进行贸易时减免 1 M€ 费用

- 其他改动：
  - 修改 Colonies.ts 支持新版公司卡的费用减免逻辑