### PR TITLE
fix: 修复 Solar Station 无法执行行动的 bug

### DIFF
--- a/src/server/cards/chemical/SolarStation.ts
+++ b/src/server/cards/chemical/SolarStation.ts
@@ -1,12 +1,12 @@
 import {IProjectCard} from '../IProjectCard';
-import {Card} from '../Card';
+import {ActionCard} from '../ActionCard';
 import {CardType} from '../../../common/cards/CardType';
 import {Tag} from '../../../common/cards/Tag';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {digit} from '../Options';
 
-export class SolarStation extends Card implements IProjectCard {
+export class SolarStation extends ActionCard implements IProjectCard {
   constructor() {
     super({
       name: CardName.SOLAR_STATION,


### PR DESCRIPTION
- 将 SolarStation 从继承 Card 改为继承 ActionCard
- 原因：Solar Station 定义了行动（抽1牌），但未继承 ActionCard，导致无法触发行动逻辑