### PR TITLE
feat: 添加公司卡牌 RB-CORP-12 - Factorum Rebalanced

### DIFF
--- a/src/client/components/card/CardCorporationLogo.vue
+++ b/src/client/components/card/CardCorporationLogo.vue
@@ -223,6 +223,7 @@ const imageLogosWithNames: Map<CardName, string> = new Map([
   [CardName.ECOLINE, 'card-ecoline-logo'],
   [CardName.HELION, 'card-helion-logo'],
   [CardName.FACTORUM, 'card-factorum-logo'],
+  [CardName.FACTORUM_REBALANCED, 'card-factorum-logo'],
   [CardName.PHOBOLOG, 'card-phobolog-logo'],
   [CardName.POINT_LUNA, 'card-luna-logo'],
   [CardName.POLYPHEMOS, 'card-polyphemos-logo'],

--- a/src/common/cards/CardName.ts
+++ b/src/common/cards/CardName.ts
@@ -650,6 +650,7 @@ export enum CardName {
   ADHAI_HIGH_ORBIT_CONSTRUCTIONS_REBALANCED = 'Adhai High Orbit Constructions Rebalanced',
   INVENTRIX_REBALANCED = 'Inventrix Rebalanced',
   MIDAS_REBALANCED = 'Midas Rebalanced',
+  FACTORUM_REBALANCED = 'Factorum Rebalanced',
 
   // Rebalanced preludes
 

--- a/src/locales/cn/base_cards.json
+++ b/src/locales/cn/base_cards.json
@@ -308,10 +308,10 @@
   "Bushes": "花丛",
   "Requires -10 C or warmer. Increase your plant production 2 steps. Gain 2 plants.": "需要至少-10度。增加你的植物产量2级，获得2个植物资源。",
 
-  "Mass Converter": "大规模转换器",
+  "Mass Converter": "质量转换器",
   "Requires 5 science tags. Increase your energy production 6 steps.": "需要5个科学标志。增加你的电力产量6级。",
 
-  "Physics Complex": "物理复杂性",
+  "Physics Complex": "物理中心",
   "Action: Spend 6 energy to add a science resource to this card.": "行动： 花费6个电力资源，放置一个资源在本卡。",
   "2 VP for each science resource on this card.": "本卡上每有1个资源，获得2分。",
 
@@ -710,10 +710,10 @@
   "Decrease your energy production 1 step and increase your M€ production 2 steps. Place a city tile on a VOLCANIC AREA regardless of adjacent cities.": "能量产量-1，M€产量+2。将城市放置在火山区域，无视相邻城市要求。",
   "Effect: When paying for a plant card, microbes here may be used as 2 M€ each.": "效果：支付植物牌时，此处的微生物每个可视为2 M€。",
   "Temperature must be -20 C or lower.": "温度必须为-20°C或更低。",
-  "Increase your energy production 1 step": "能量产量+1",
-  "Increase your energy production 2 steps": "增加你的电力产量2级。",
-  "Increase your energy production 3 steps": "能量产量+3",
-  "Increase your plant production 1 step": "增加你的植物产量1级",
+  "Increase your energy production 1 step": "提升1点电力产量",
+  "Increase your energy production 2 steps": "提升2点电力产量",
+  "Increase your energy production 3 steps": "提升3点电力产量",
+  "Increase your plant production 1 step": "提升1点植物产量",
   "Remove 2 microbes to raise temperature 1 step": "移除2个微生物，使温度上升1格",
   "Select card to add 2 microbes": "选择1张牌添加2个微生物",
   "Add microbes": "添加微生物",

--- a/src/locales/cn/rebalanced_corporations.json
+++ b/src/locales/cn/rebalanced_corporations.json
@@ -76,6 +76,17 @@
   "MIDAS_REBALANCED": "MIDAS",
   "Midas Rebalanced": "Midas",
   "MIDAS REBALANCED": "MIDAS",
-  "You start with 100 M€. Lower your TR 4 steps.": "起始获得100 M€，降低4点改造度。"
+  "You start with 100 M€. Lower your TR 4 steps.": "起始获得100 M€，降低4点改造度。",
 
+  "Factorum_Rebalanced": "Factorum",
+  "FACTORUM_REBALANCED": "FACTORUM",
+  "Factorum Rebalanced": "Factorum",
+  "FACTORUM REBALANCED": "FACTORUM",
+  "You start with 37 M€. Increase your steel and energy production 1 step.": "起始获得37 M€，提升1点钢铁和电力产量。",
+  "least": "最少",
+  "most": "最多",
+  "Action: If you have (or are tied for) the least energy resources, Increase your energy production 1 step.": "行动：如果你拥有最少的电力资源（包括并列），提升1点电力产量。",
+  "Action: If you have (or are tied for) the most steel resources, draw a building card.": "行动：如果你拥有最多的钢铁资源（包括并列），抽1张建筑牌。",
+  "Increase your energy production 1 step": "提升1点电力产量",
+  "Draw a building card": "抽一张建筑牌"
 }

--- a/src/server/cards/rebalanced/FactorumRebalanced.ts
+++ b/src/server/cards/rebalanced/FactorumRebalanced.ts
@@ -1,0 +1,80 @@
+import {CorporationCard} from '../corporation/CorporationCard';
+import {IPlayer} from '../../IPlayer';
+import {Tag} from '../../../common/cards/Tag';
+import {IActionCard} from '../ICard';
+import {Resource} from '../../../common/Resource';
+import {CardName} from '../../../common/cards/CardName';
+import {CardRenderer} from '../render/CardRenderer';
+import {Size} from '../../../common/cards/render/Size';
+import {SelectOption} from '../../../server/inputs/SelectOption';
+import {OrOptions} from '../../../server/inputs/OrOptions';
+
+export class FactorumRebalanced extends CorporationCard implements IActionCard {
+  constructor() {
+    super({
+      name: CardName.FACTORUM_REBALANCED,
+      tags: [Tag.POWER, Tag.BUILDING],
+      startingMegaCredits: 37,
+
+      behavior: {
+        production: {steel: 1, energy: 1},
+      },
+
+      metadata: {
+        cardNumber: 'RB-CORP-12',
+        description: 'You start with 37 M€. Increase your steel and energy production 1 step.',
+        renderData: CardRenderer.builder((b) => {
+          b.megacredits(37).nbsp.production((pb) => pb.steel(1).energy(1));
+          b.corpBox('action', (ce) => {
+            ce.vSpace(Size.MEDIUM);
+            ce.action('If you have (or are tied for) the least energy resources, Increase your energy production 1 step.', (eb) => {
+              eb.text('least').energy(1).startAction.production((pb) => pb.energy(1));
+            });
+            ce.action('If you have (or are tied for) the most steel resources, draw a building card.', (eb) => {
+              eb.text('most').steel(1).startAction.cards(1, {secondaryTag: Tag.BUILDING});
+            });
+          });
+        }),
+      },
+    });
+  }
+
+  private hasLeastEnergy(player: IPlayer): boolean {
+    const energies = player.game.getPlayers().map((p) => p.energy);
+    const minEnergy = Math.min(...energies);
+    return player.energy === minEnergy;
+  }
+
+  private hasMostSteel(player: IPlayer): boolean {
+    const steels = player.game.getPlayers().map((p) => p.steel);
+    const maxSteel = Math.max(...steels);
+    return player.steel === maxSteel;
+  }
+
+  public canAct(player: IPlayer): boolean {
+    return this.hasLeastEnergy(player) || this.hasMostSteel(player);
+  }
+
+  public action(player: IPlayer) {
+    const increaseEnergy = new SelectOption(
+      'Increase your energy production 1 step',
+      'Increase production')
+      .andThen(() => {
+        player.production.add(Resource.ENERGY, 1, {log: true});
+        return undefined;
+      });
+
+    const drawBuildingCard = new SelectOption(
+      'Draw a building card',
+      'Draw card')
+      .andThen(() => {
+        player.drawCard(1, {tag: Tag.BUILDING});
+        return undefined;
+      });
+
+    if (!this.hasLeastEnergy(player)) return drawBuildingCard;
+    if (!this.hasMostSteel(player)) return increaseEnergy;
+
+    return new OrOptions(increaseEnergy, drawBuildingCard);
+  }
+}

--- a/src/server/cards/rebalanced/RebalancedCardManifest.ts
+++ b/src/server/cards/rebalanced/RebalancedCardManifest.ts
@@ -3,6 +3,7 @@ import {ModuleManifest} from '../ModuleManifest';
 import {AdhaiHighOrbitConstructionsRebalanced} from './AdhaiHighOrbitConstructionsRebalanced';
 import {ArklightRebalanced} from './ArklightRebalanced';
 import {CelesticRebalanced} from './CelesticRebalanced';
+import {FactorumRebalanced} from './FactorumRebalanced';
 import {InterplanetaryCinematicsRebalanced} from './InterplanetaryCinematicsRebalanced';
 import {InventrixRebalanced} from './InventrixRebalanced';
 import {MidasRebalanced} from './MidasRebalanced';
@@ -26,6 +27,7 @@ export const REBALANCED_CARD_MANIFEST = new ModuleManifest({
     [CardName.ADHAI_HIGH_ORBIT_CONSTRUCTIONS_REBALANCED]: {Factory: AdhaiHighOrbitConstructionsRebalanced},
     [CardName.INVENTRIX_REBALANCED]: {Factory: InventrixRebalanced},
     [CardName.MIDAS_REBALANCED]: {Factory: MidasRebalanced},
+    [CardName.FACTORUM_REBALANCED]: {Factory: FactorumRebalanced},
   },
   preludeCards: {
   },
@@ -45,5 +47,6 @@ export const REBALANCED_CARD_MANIFEST = new ModuleManifest({
     CardName.ADHAI_HIGH_ORBIT_CONSTRUCTIONS,
     CardName.INVENTRIX,
     CardName.MIDAS,
+    CardName.FACTORUM,
   ],
 });


### PR DESCRIPTION
基于原版公司 Factorum 进行数值与效果重构，改动内容如下：

- 起始产量由「+1 钢铁」调整为「+1 钢铁、+1 能量」
- 修改公司行动效果：
  - 若你拥有最少的能量资源（允许并列），则获得 +1 能量产量
  - 若你拥有最多的钢铁资源（允许并列），则抽一张建筑牌
  - 若两个条件均满足，可选择其中之一执行