### PR TITLE
feat: 添加 MingYue 扩展卡牌 MY15–MY17 - 贫民窟、加班、偷猎者

### DIFF
--- a/src/common/cards/CardName.ts
+++ b/src/common/cards/CardName.ts
@@ -618,6 +618,9 @@ export enum CardName {
   MICROBIAL_REACTOR = 'Microbial Reactor',
   MARS_MONUMENT = 'Mars Monument',
   EXPANSION_OF_POPULATION = 'Expansion Of Population',
+  SLUM = 'Slum',
+  OVERTIME = 'Overtime',
+  POACHERS = 'Poachers',
 
   // MingYue corps
   TRISYN_INSTITUTE = 'Trisyn Institute',

--- a/src/locales/cn/base_cards.json
+++ b/src/locales/cn/base_cards.json
@@ -389,7 +389,7 @@
   "Requires 3 or less ocean tiles.": "需要不多于3个海洋板块在场。",
 
   "Urbanized Area": "城市化区域",
-  "Decrease your energy production 1 step and increase your M€ production 2 steps. Place a city tile ADJACENT TO AT LEAST 2 OTHER CITY TILES.": "能量产量-1，M€产量+2。将城市放置在**至少邻接2座城市**的位置。",
+  "Decrease your energy production 1 step and increase your M€ production 2 steps. Place a city tile ADJACENT TO AT LEAST 2 OTHER CITY TILES.": "能量产量-1，M€产量+2。将城市放置在至少邻接2座城市的位置。",
 
   "Sabotage": "蓄意破坏",
   "Remove up to 3 titanium from any player, or 4 steel, or 7 M€.": "移除任一玩家的最多3个钛资源,或4个钢铁资源，或7 M€。",

--- a/src/locales/cn/base_corporations.json
+++ b/src/locales/cn/base_corporations.json
@@ -30,7 +30,7 @@
   "INVENTRIX": "发明矩阵",
   "Inventrix": "发明矩阵",
   "As your first action in the game, draw 3 cards. Start with 45 M€.": "起始获得45 M€。作为你的第一个行动，抽3张牌。",
-  "Effect: Your temperature, oxygen, ocean, and Venus requirements are +2 or -2 steps, your choice in each case.": "效果：你打牌时的 温度/氧气浓度/海洋 要求 +2级或-2级。",
+  "Effect: Your temperature, oxygen, ocean, and Venus requirements are +2 or -2 steps, your choice in each case.": "效果：你打牌时的 温度/氧气/海洋/金星 要求 +2级或-2级。",
   "Draw 3 cards": "抽三张牌",
 
   "PhoboLog": "火卫一日志",

--- a/src/locales/cn/mingyue_cards.json
+++ b/src/locales/cn/mingyue_cards.json
@@ -67,6 +67,14 @@
   "Requires that you have at least 35 TR. Place the Mars Monument tile — a silent monument to humanity’s dream of Terraforming Mars.": "需要你至少有35点TR。放置火星丰碑板块，献给人类地球化火星梦想的无声纪念。",
 
   "Expansion Of Population": "种群扩张",
-  "Spend 3 plants to add 3 animals to ANY card.": "消耗3个植物，将3个动物添加到任意一张卡牌上。"
+  "Spend 3 plants to add 3 animals to ANY card.": "消耗3个植物，将3个动物添加到任意一张卡牌上。",
 
+  "Slum": "贫民窟",
+  "Decrease your energy production 1 step. Place a city tile ADJACENT TO AT LEAST 1 OTHER CITY TILE.": "降低电力产量1级，将城市板块放置在至少邻接1座城市的位置。",
+
+  "Overtime": "加班",
+  "Take another two actions this turn.": "本回合额外执行两次行动。",
+
+  "Poachers": "偷猎者",
+  "Move 1 resource from any card to another card with the same resource type that already has resources.": "将任意卡牌上的1个资源转移至另一张具有相同资源类型且已有资源的卡牌。"
 }

--- a/src/locales/cn/pathfinder_corporations.json
+++ b/src/locales/cn/pathfinder_corporations.json
@@ -41,7 +41,7 @@
 
   "Mars Maths": "火星数学",
   "(Effect: At the beginning of the Research phase, you draw 5 cards, but may STILL only buy 4 cards. If you are drafting, keep 2 cards for your first draft.)": "（效果：在研究阶段开始时，你抽取5张卡牌，但仍然只能购买4张卡牌。如果是轮抽模式，你可以在第一轮轮抽选择保留2张卡牌。）",
-  "(Action: Take another two actions this turn.)": "（行动：在本回合中额外执行两次行动。）",
+  "(Action: Take another two actions this turn.)": "（行动：本回合额外执行两次行动。）",
   "(You start with 40 M€. As your first action, draw 2 cards)": "（起始获得40M€。作为游戏的第一个行动，抽2张牌。）",
 
   "Martian Insurance Group": "火星保险集团",

--- a/src/locales/cn/rebalanced_corporations.json
+++ b/src/locales/cn/rebalanced_corporations.json
@@ -66,6 +66,7 @@
   "INVENTRIX_REBALANCED": "INVENTRIX",
   "Inventrix Rebalanced": "Inventrix",
   "INVENTRIX REBALANCED": "INVENTRIX",
+  "Effect: Your temperature, oxygen, ocean, and Venus requirements are +3 or -3 steps, your choice in each case.": "效果：你打牌时的 温度/氧气/海洋/金星 要求 +3级或-3级。",
   "Effect: When you use the global requirement modifier to play a card, gain 3 M€.": "效果：当你使用全球参数修正来打出一张牌时，获得 3 M€。",
   "${0} gained 3 M€ from ${1} effect. Parameter: venus, Current: ${2}, Required: ${3}.": "${0} 通过 ${1} 效果获得了 3 M€。参数：金星，当前值：${2}，需求值：${3}。",
   "${0} gained 3 M€ from ${1} effect. Parameter: oxygen, Current: ${2}, Required: ${3}.": "${0} 通过 ${1} 效果获得了 3 M€。参数：氧气，当前值：${2}，需求值：${3}。",

--- a/src/locales/cn/ui.json
+++ b/src/locales/cn/ui.json
@@ -736,6 +736,8 @@
   "Select card to remove 1 microbe from": "选择卡牌移除1个微生物",
   "Select card to remove 2 Microbe(s)": "选择卡牌移除2个微生物",
   "Select card to remove 1 Floater(s)": "选择卡牌移除1个云资源",
+  "Select card to remove 1 Data(s)": "选择卡牌移除1个数据",
+  "Select card to remove 2 Data(s)": "选择卡牌移除2个数据",
   "Select card to remove 3 Data(s)": "选择卡牌移除3个数据",
   "Select card to add microbe or animal": "选择卡牌添加微生物或动物",
   "Add resource to card ${0}": "向${0}卡添加资源",

--- a/src/server/awards/terraCimmeria/Warmonger.ts
+++ b/src/server/awards/terraCimmeria/Warmonger.ts
@@ -79,6 +79,8 @@ export class Warmonger implements IAward {
     // Prelude 2
     CardName.RECESSION,
     CardName.SPECIAL_PERMIT,
+    // MingYue
+    CardName.POACHERS,
     // Chemical
     CardName.POWER_FAILURE,
     CardName.PARASITE,

--- a/src/server/cards/mingyue/MingYueCardManifest.ts
+++ b/src/server/cards/mingyue/MingYueCardManifest.ts
@@ -25,6 +25,9 @@ import {RainbowPark} from './RainbowPark';
 import {ExpansionOfPopulation} from './ExpansionOfPopulation';
 import {ForesightTechnologies} from './ForesightTechnologies';
 import {ImmediateActionCorp} from './ImmediateActionCorp';
+import {Slum} from './Slum';
+import {Overtime} from './Overtime';
+import {Poachers} from './Poachers';
 
 export const MINGYUE_CARD_MANIFEST = new ModuleManifest({
   module: 'mingyue',
@@ -58,6 +61,9 @@ export const MINGYUE_CARD_MANIFEST = new ModuleManifest({
     [CardName.MARS_MONUMENT]: {Factory: MarsMonument},
     [CardName.EXPANSION_OF_POPULATION]: {Factory: ExpansionOfPopulation},
     [CardName.GAMBLING_DISTRICT_LAS_VEGAS]: {Factory: GamblingDistrictLasVegas, compatibility: 'ares'},
+    [CardName.SLUM]: {Factory: Slum},
+    [CardName.OVERTIME]: {Factory: Overtime},
+    [CardName.POACHERS]: {Factory: Poachers},
   },
   globalEvents: {
   },

--- a/src/server/cards/mingyue/Overtime.ts
+++ b/src/server/cards/mingyue/Overtime.ts
@@ -1,0 +1,29 @@
+import {IProjectCard} from '../IProjectCard';
+import {Card} from '../Card';
+import {CardType} from '../../../common/cards/CardType';
+import {CardName} from '../../../common/cards/CardName';
+import {CardRenderer} from '../render/CardRenderer';
+import {IPlayer} from '../../../server/IPlayer';
+
+export class Overtime extends Card implements IProjectCard {
+  constructor() {
+    super({
+      name: CardName.OVERTIME,
+      cost: 4,
+      type: CardType.EVENT,
+
+      metadata: {
+        cardNumber: 'MY16',
+        description: 'Take another two actions this turn.',
+        renderData: CardRenderer.builder((b) => {
+          b.arrow().arrow();
+        }),
+      },
+    });
+  }
+
+  public override bespokePlay(player: IPlayer) {
+    player.availableActionsThisRound += 2;
+    return undefined;
+  }
+}

--- a/src/server/cards/mingyue/Poachers.ts
+++ b/src/server/cards/mingyue/Poachers.ts
@@ -1,0 +1,62 @@
+import {IProjectCard} from '../IProjectCard';
+import {Card} from '../Card';
+import {CardType} from '../../../common/cards/CardType';
+import {CardName} from '../../../common/cards/CardName';
+import {IPlayer} from '../../IPlayer';
+import {RemoveResourcesFromCard} from '../../deferredActions/RemoveResourcesFromCard';
+import {CardRenderer} from '../render/CardRenderer';
+import {OrOptions} from '../../inputs/OrOptions';
+import {all} from '../Options';
+import {SelectOption} from '../../../server/inputs/SelectOption';
+import {AddResourcesToCard} from '../../../server/deferredActions/AddResourcesToCard';
+
+export class Poachers extends Card implements IProjectCard {
+  constructor() {
+    super({
+      name: CardName.POACHERS,
+      cost: 5,
+      type: CardType.EVENT,
+      metadata: {
+        cardNumber: 'MY17',
+        description: 'Move 1 resource from any card to another card with the same resource type that already has resources.',
+        renderData: CardRenderer.builder((b) => {
+          b.minus().wild(1, {all}).nbsp.plus().wild(1).asterix();
+        }),
+      },
+    });
+  }
+
+  private getOwnedResourceTypes(player: IPlayer) {
+    return [...new Set(
+      player.getCardsWithResources().map((card) => card.resourceType),
+    )];
+  }
+
+  public override bespokePlay(player: IPlayer) {
+    const orOptions = new OrOptions();
+    const resourceTypes = this.getOwnedResourceTypes(player);
+    for (const resourceType of resourceTypes) {
+      const resourceRemovalOptions = new RemoveResourcesFromCard(
+        player,
+        resourceType,
+        1,
+        {mandatory: false, log: true},
+      )
+        .andThen((response) => {
+          if (response.proceed) {
+            player.game.defer(new AddResourcesToCard(player, resourceType, {count: 1}));
+          }
+        })
+        .execute() as OrOptions;
+      const removalOption = resourceRemovalOptions !== undefined ?
+        resourceRemovalOptions.options[0] :
+        undefined;
+      if (removalOption !== undefined) {
+        orOptions.options.push(removalOption);
+      }
+    }
+
+    orOptions.options.push(new SelectOption('Skip removal'));
+    return orOptions;
+  }
+}

--- a/src/server/cards/mingyue/Slum.ts
+++ b/src/server/cards/mingyue/Slum.ts
@@ -1,0 +1,53 @@
+import {IProjectCard} from '../IProjectCard';
+import {Card} from '../Card';
+import {CardType} from '../../../common/cards/CardType';
+import {Tag} from '../../../common/cards/Tag';
+import {CardName} from '../../../common/cards/CardName';
+import {CardRenderer} from '../render/CardRenderer';
+import {IPlayer, CanAffordOptions} from '../../IPlayer';
+import {Space} from '../../boards/Space';
+import {Board} from '../../boards/Board';
+import {PlaceCityTile} from '../../deferredActions/PlaceCityTile';
+
+export class Slum extends Card implements IProjectCard {
+  constructor() {
+    super({
+      name: CardName.SLUM,
+      cost: 6,
+      type: CardType.AUTOMATED,
+      tags: [Tag.CITY, Tag.BUILDING],
+      victoryPoints: -1,
+
+      behavior: {
+        production: {energy: -1},
+      },
+
+      metadata: {
+        cardNumber: 'MY15',
+        description: 'Decrease your energy production 1 step. Place a city tile ADJACENT TO AT LEAST 1 OTHER CITY TILE.',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => {
+            pb.minus().energy(1);
+          }).city().asterix();
+        }),
+      },
+    });
+  }
+
+  private getAvailableSpaces(player: IPlayer, canAffordOptions?: CanAffordOptions): Array<Space> {
+    return player.game.board.getAvailableSpacesOnLand(player, canAffordOptions)
+      .filter((space) => player.game.board.getAdjacentSpaces(space).some((adjacentSpace) => Board.isCitySpace(adjacentSpace)));
+  }
+
+  public override bespokeCanPlay(player: IPlayer, canAffordOptions: CanAffordOptions): boolean {
+    return this.getAvailableSpaces(player, canAffordOptions).length > 0;
+  }
+
+  public override bespokePlay(player: IPlayer) {
+    player.game.defer(new PlaceCityTile(player, {
+      title: 'Select space adjacent to a city tile',
+      spaces: this.getAvailableSpaces(player),
+    }));
+    return undefined;
+  }
+}

--- a/src/server/cards/rebalanced/InventrixRebalanced.ts
+++ b/src/server/cards/rebalanced/InventrixRebalanced.ts
@@ -8,7 +8,7 @@ import {RequirementType} from '../../../common/cards/RequirementType';
 import {requirementType} from '../../../common/cards/CardRequirementDescriptor';
 import {Size} from '../../../common/cards/render/Size';
 
-const GLOBAL_REQUIREMENT_MODIFIER = 2;
+const GLOBAL_REQUIREMENT_MODIFIER = 3;
 
 const stepValues = {
   venus: 2,
@@ -38,8 +38,8 @@ export class InventrixRebalanced extends Inventrix {
           b.megacredits(45).nbsp.cards(3);
           b.corpBox('effect', (ce) => {
             ce.vSpace(Size.LARGE);
-            ce.effect('Your temperature, oxygen, ocean, and Venus requirements are +2 or -2 steps, your choice in each case.', (eb) => {
-              eb.plate('Global requirements').startEffect.text('+/- 2');
+            ce.effect('Your temperature, oxygen, ocean, and Venus requirements are +3 or -3 steps, your choice in each case.', (eb) => {
+              eb.plate('Global requirements').startEffect.text('+/- 3');
             });
             ce.effect('When you use the global requirement modifier to play a card, gain 3 M€.', (eb) => {
               eb.cards(1).plate('Global requirements').asterix().startEffect.megacredits(3);

--- a/tests/awards/terraCimmeria/Warmonger.spec.ts
+++ b/tests/awards/terraCimmeria/Warmonger.spec.ts
@@ -49,6 +49,7 @@ describe('Warmonger', () => {
     CardName.REVOLTING_COLONISTS, CardName.ROAD_PIRACY, CardName.SABOTAGE, CardName.SERVER_SABOTAGE,
     CardName.SMALL_ASTEROID, CardName.SMALL_COMET, CardName.SOLAR_STORM, CardName.SPECIAL_PERMIT,
     CardName.VIRUS,
+    CardName.POACHERS,
     CardName.HIGH_SPEED_COMET, CardName.POWER_FAILURE, CardName.PARASITE,
   ] as const;
   for (const manifest of ALL_MODULE_MANIFESTS) {


### PR DESCRIPTION
- MY15: Slum - 降低电力产量1级，将城市板块放置在至少邻接1座城市的位置 （贫民窟）
- MY16: Overtime - 本回合额外执行两次行动 （加班）
- MY17: Poachers - 将任意卡牌上的1个资源转移至另一张具有相同资源类型且已有资源的卡牌 （偷猎者）
------------
-
  平衡性调整 Inventrix_Rebalanced 的参数修正步数由 2 改为 3