### PR TITLE
feat: 添加重平衡公司卡牌 & 优化明月扩展卡牌逻辑

### DIFF
--- a/src/client/components/card/CardCorporationLogo.vue
+++ b/src/client/components/card/CardCorporationLogo.vue
@@ -54,7 +54,7 @@
     <template v-else-if="title === CardName.LAKEFRONT_RESORTS">
       <div class="card-lakefront-logo">LAKEFRONT <br> &nbsp;&nbsp;RESORTS</div>
     </template>
-    <template v-else-if="title === CardName.MINING_GUILD">
+    <template v-else-if="title === CardName.MINING_GUILD || title === CardName.MINING_GUILD_REBALANCED">
       <span class="card-mining-guild-logo">MINING<br>GUILD</span>
     </template>
     <template v-else-if="title === CardName.PHILARES">

--- a/src/client/components/card/CardCorporationLogo.vue
+++ b/src/client/components/card/CardCorporationLogo.vue
@@ -222,6 +222,7 @@ const imageLogosWithNames: Map<CardName, string> = new Map([
   [CardName.CREDICOR, 'card-credicor-logo'],
   [CardName.ECOLINE, 'card-ecoline-logo'],
   [CardName.HELION, 'card-helion-logo'],
+  [CardName.HELION_REBALANCED, 'card-helion-logo'],
   [CardName.FACTORUM, 'card-factorum-logo'],
   [CardName.FACTORUM_REBALANCED, 'card-factorum-logo'],
   [CardName.PHOBOLOG, 'card-phobolog-logo'],

--- a/src/client/components/overview/PlayerResources.vue
+++ b/src/client/components/overview/PlayerResources.vue
@@ -63,7 +63,7 @@ export default Vue.extend({
     },
     // TODO LUNA TRADE FEDERATION
     canUseHeatAsMegaCredits(): boolean {
-      return this.player.tableau.some((card) => card.name === CardName.HELION);
+      return this.player.tableau.some((card) => card.name === CardName.HELION || card.name === CardName.HELION_REBALANCED);
     },
   },
   components: {

--- a/src/common/cards/CardName.ts
+++ b/src/common/cards/CardName.ts
@@ -656,6 +656,7 @@ export enum CardName {
   INVENTRIX_REBALANCED = 'Inventrix Rebalanced',
   MIDAS_REBALANCED = 'Midas Rebalanced',
   FACTORUM_REBALANCED = 'Factorum Rebalanced',
+  HELION_REBALANCED = 'Helion Rebalanced',
 
   // Rebalanced preludes
 

--- a/src/common/cards/CardName.ts
+++ b/src/common/cards/CardName.ts
@@ -657,6 +657,7 @@ export enum CardName {
   MIDAS_REBALANCED = 'Midas Rebalanced',
   FACTORUM_REBALANCED = 'Factorum Rebalanced',
   HELION_REBALANCED = 'Helion Rebalanced',
+  MINING_GUILD_REBALANCED = 'Mining Guild Rebalanced',
 
   // Rebalanced preludes
 

--- a/src/locales/cn/mingyue_corporations.json
+++ b/src/locales/cn/mingyue_corporations.json
@@ -40,9 +40,9 @@
   "INFINITY CIRCUIT": "无限回路",
   "You start with 42 M€, and 2 each of plants, energy, and heat.": "起始获得42M€，2 个植物、电力和热能。",
   "Effect: When you spend 3 or more plants, energy, or heat, gain 2 energy, 2 heat, or 1 plant, respectively.": "效果：当你消耗 3 个或更多的植物、电力或热能时，分别获得 2 个电力、2 个热能或 1 个植物。",
-  "${0} gained ${1} energy via ${2} (paid ${3} plants)": "${0} 通过 ${2} 获得了 ${1} 电力（支付了 ${3} 个植物）",
-  "${0} gained ${1} heat via ${2} (paid ${3} energy)": "${0} 通过 ${2} 获得了 ${1} 热能（支付了 ${3} 个电力）",
-  "${0} gained ${1} plant via ${2} (paid ${3} heat)": "${0} 通过 ${2} 获得了 ${1} 植物（支付了 ${3} 个热能）",
+  "${0} gained ${1} energy via ${2} (spent ${3} plants)": "${0} 通过 ${2} 获得了 ${1} 电力（消耗了 ${3} 个植物）",
+  "${0} gained ${1} heat via ${2} (spent ${3} energy)": "${0} 通过 ${2} 获得了 ${1} 热能（消耗了 ${3} 个电力）",
+  "${0} gained ${1} plant via ${2} (spent ${3} heat)": "${0} 通过 ${2} 获得了 ${1} 植物（消耗了 ${3} 个热能）",
 
   "Heavyworks Creed": "重工信条",
   "HEAVYWORKS CREED": "重工信条",

--- a/src/locales/cn/rebalanced_corporations.json
+++ b/src/locales/cn/rebalanced_corporations.json
@@ -89,5 +89,14 @@
   "Action: If you have (or are tied for) the least energy resources, Increase your energy production 1 step.": "行动：如果你拥有最少的电力资源（包括并列），提升1点电力产量。",
   "Action: If you have (or are tied for) the most steel resources, draw a building card.": "行动：如果你拥有最多的钢铁资源（包括并列），抽1张建筑牌。",
   "Increase your energy production 1 step": "提升1点电力产量",
-  "Draw a building card": "抽一张建筑牌"
+  "Draw a building card": "抽一张建筑牌",
+
+  "Helion_Rebalanced": "Helion",
+  "HELION_REBALANCED": "HELION",
+  "Helion Rebalanced": "Helion",
+  "HELION REBALANCED": "HELION",
+  "You start with 3 heat production and 42 M€.": "起始获得42 M€，提升热能产量3级。",
+  "Effect: Heat may be used as 1 M€ each. M€ may not be used as heat.": "效果：每个热能资源可抵1M€。M€不能当作热能使用。",
+  "Effect: For every 2 heat you spend, gain 1 M€.": "效果：每消耗2点热能资源，获得1M€。",
+  "${0} gained ${1} M€ via ${2} (spent ${3} heat)": "${0} 通过 ${2} 获得了 ${1} M€（消耗了 ${3} 个热能）"
 }

--- a/src/locales/cn/rebalanced_corporations.json
+++ b/src/locales/cn/rebalanced_corporations.json
@@ -98,5 +98,11 @@
   "You start with 3 heat production and 42 M€.": "起始获得42 M€，提升热能产量3级。",
   "Effect: Heat may be used as 1 M€ each. M€ may not be used as heat.": "效果：每个热能资源可抵1M€。M€不能当作热能使用。",
   "Effect: For every 2 heat you spend, gain 1 M€.": "效果：每消耗2点热能资源，获得1M€。",
-  "${0} gained ${1} M€ via ${2} (spent ${3} heat)": "${0} 通过 ${2} 获得了 ${1} M€（消耗了 ${3} 个热能）"
+  "${0} gained ${1} M€ via ${2} (spent ${3} heat)": "${0} 通过 ${2} 获得了 ${1} M€（消耗了 ${3} 个热能）",
+
+  "Mining_Guild_Rebalanced": "Mining_Guild",
+  "MINING_GUILD_REBALANCED": "MINING_GUILD",
+  "Mining Guild Rebalanced": "Mining Guild",
+  "MINING GUILD REBALANCED": "MINING GUILD",
+  "Effect: STEEL MAY BE USED for the CITY STANDARD PROJECT as if you were playing a building card.": "效果：钢铁资源可用于城市标准项目。"
 }

--- a/src/server/cards/base/standardProjects/CityStandardProject.ts
+++ b/src/server/cards/base/standardProjects/CityStandardProject.ts
@@ -24,7 +24,7 @@ export class CityStandardProject extends StandardProjectCard {
   }
 
   public override canPayWith(player: IPlayer) {
-    if (player.getPlayedCard(CardName.PREFABRICATION_OF_HUMAN_HABITATS)) {
+    if (player.getPlayedCard(CardName.PREFABRICATION_OF_HUMAN_HABITATS) || player.getCorporation(CardName.MINING_GUILD_REBALANCED)) {
       return {steel: true};
     } else {
       return {};

--- a/src/server/cards/mingyue/ResourcePlanningBureau.ts
+++ b/src/server/cards/mingyue/ResourcePlanningBureau.ts
@@ -7,6 +7,7 @@ import {IPlayer} from '../../IPlayer';
 import {ICard} from '../ICard';
 import {CardRenderer} from '../render/CardRenderer';
 import {Payment} from '../../../common/inputs/Payment';
+import {Resource} from '../../../common/Resource';
 
 export class ResourcePlanningBureau extends Card implements IProjectCard {
   constructor() {
@@ -38,8 +39,8 @@ export class ResourcePlanningBureau extends Card implements IProjectCard {
     // 确保支付的 M€ 为 0，且支付了至少1个其他资源
     if (payment.megaCredits === 0 && Object.values(payment).some((value) => value > 0)) {
       const gain = 2;
-      player.megaCredits += 2;
 
+      player.stock.add(Resource.MEGACREDITS, gain, {log: false});
       player.game.log(
         '${0} gained ${1} M€ from ${2} effect.',
         (b) => b.player(player).number(gain).card(this),

--- a/src/server/cards/mingyue/corporations/InfinityCircuit.ts
+++ b/src/server/cards/mingyue/corporations/InfinityCircuit.ts
@@ -52,7 +52,7 @@ export class InfinityCircuit extends CorporationCard {
     if (resource === Resource.PLANTS && amount >= PLANTS_TO_ENERGY_THRESHOLD) {
       player.stock.add(Resource.ENERGY, PLANTS_TO_ENERGY_GAIN, {log: false});
       player.game.log(
-        '${0} gained ${1} energy via ${2} (paid ${3} plants)',
+        '${0} gained ${1} energy via ${2} (spent ${3} plants)',
         (b) => b.player(player).number(PLANTS_TO_ENERGY_GAIN).card(this).number(amount),
       );
     }
@@ -60,7 +60,7 @@ export class InfinityCircuit extends CorporationCard {
     if (resource === Resource.ENERGY && amount >= ENERGY_TO_HEAT_THRESHOLD) {
       player.stock.add(Resource.HEAT, ENERGY_TO_HEAT_GAIN, {log: false});
       player.game.log(
-        '${0} gained ${1} heat via ${2} (paid ${3} energy)',
+        '${0} gained ${1} heat via ${2} (spent ${3} energy)',
         (b) => b.player(player).number(ENERGY_TO_HEAT_GAIN).card(this).number(amount),
       );
     }
@@ -68,7 +68,7 @@ export class InfinityCircuit extends CorporationCard {
     if (resource === Resource.HEAT && amount >= HEAT_TO_PLANTS_THRESHOLD) {
       player.stock.add(Resource.PLANTS, HEAT_TO_PLANTS_GAIN, {log: false});
       player.game.log(
-        '${0} gained ${1} plant via ${2} (paid ${3} heat)',
+        '${0} gained ${1} plant via ${2} (spent ${3} heat)',
         (b) => b.player(player).number(HEAT_TO_PLANTS_GAIN).card(this).number(amount),
       );
     }

--- a/src/server/cards/mingyue/corporations/LunaChain.ts
+++ b/src/server/cards/mingyue/corporations/LunaChain.ts
@@ -7,6 +7,7 @@ import {ICard} from '../../ICard';
 import {IPlayer} from '../../../IPlayer';
 import {Payment} from '../../../../common/inputs/Payment';
 import {getLunaChainData} from '../../../mingyue/MingYueData';
+import {Resource} from '../../../../common/Resource';
 
 export class LunaChain extends CorporationCard {
   constructor() {
@@ -52,9 +53,9 @@ export class LunaChain extends CorporationCard {
 
       if (diff < 3) {
         const gain = 3 - diff;
-        player.megaCredits += gain;
-        data.totalGain += gain;
 
+        data.totalGain += gain;
+        player.stock.add(Resource.MEGACREDITS, gain, {log: false});
         player.game.log(
           '${0} gained ${1} M€ due to ${2} effect.',
           (b) => b.player(player).number(gain).card(this),

--- a/src/server/cards/mingyue/corporations/NookConstruction.ts
+++ b/src/server/cards/mingyue/corporations/NookConstruction.ts
@@ -7,7 +7,6 @@ import {Size} from '../../../../common/cards/render/Size';
 import {BoardType} from '../../../boards/BoardType';
 import {SpaceType} from '../../../../common/boards/SpaceType';
 import {Resource} from '../../../../common/Resource';
-import {GainResources} from '../../../deferredActions/GainResources';
 import {Space} from '../../../boards/Space';
 import {isSpecialTileSpace} from '../../../boards/Board';
 import {CardResource} from '../../../../common/CardResource';
@@ -78,7 +77,7 @@ export class NookConstruction extends CorporationCard {
     const bellsCount = this.resourceCount;
     const income = Math.floor(bellsCount / BELLS_TO_MEGACREDIT_RATIO) + 2;
 
-    game.defer(new GainResources(cardOwner, Resource.MEGACREDITS, {count: income, log: false}));
+    cardOwner.stock.add(Resource.MEGACREDITS, income, {log: false});
     game.log(
       '${0} gained ${1} M€ from ${2} after placing a tile on Mars.',
       (b) => b.player(cardOwner).number(income).card(this),

--- a/src/server/cards/rebalanced/HelionRebalanced.ts
+++ b/src/server/cards/rebalanced/HelionRebalanced.ts
@@ -1,0 +1,55 @@
+import {Tag} from '../../../common/cards/Tag';
+import {IPlayer} from '../../IPlayer';
+import {CardName} from '../../../common/cards/CardName';
+import {CardRenderer} from '../render/CardRenderer';
+import {CorporationCard} from '../corporation/CorporationCard';
+import {Resource} from '../../../common/Resource';
+import {Size} from '../../../common/cards/render/Size';
+
+export class HelionRebalanced extends CorporationCard {
+  constructor() {
+    super({
+      name: CardName.HELION_REBALANCED,
+      tags: [Tag.SPACE],
+      startingMegaCredits: 42,
+
+      behavior: {
+        production: {heat: 3},
+      },
+
+      metadata: {
+        cardNumber: 'RB-CORP-13',
+        description: 'You start with 3 heat production and 42 M€.',
+        renderData: CardRenderer.builder((b) => {
+          b.br;
+          b.production((pb) => pb.heat(3)).nbsp.megacredits(42);
+          b.corpBox('effect', (ce) => {
+            ce.vSpace(Size.MEDIUM);
+            ce.effect('Heat may be used as 1 M€ each. M€ may not be used as heat.', (eb) => {
+              eb.startEffect.text('x').heat(1).equals().megacredits(1, {text: 'x'});
+            });
+            ce.effect('For every 2 heat you spend, gain 1 M€.', (eb) => {
+              eb.text('2x').heat(1).startEffect.megacredits(1, {text: 'x'});
+            });
+          });
+        }),
+      },
+    });
+  }
+
+  public override bespokePlay(player: IPlayer) {
+    player.canUseHeatAsMegaCredits = true;
+    return undefined;
+  }
+
+  public onStandardResourceSpent(player: IPlayer, resource: Resource, amount: number) {
+    if (resource === Resource.HEAT && amount >= 2) {
+      const gain = Math.floor(amount / 2);
+      player.stock.add(Resource.MEGACREDITS, gain, {log: false});
+      player.game.log(
+        '${0} gained ${1} M€ via ${2} (spent ${3} heat)',
+        (b) => b.player(player).number(gain).card(this).number(amount),
+      );
+    }
+  }
+}

--- a/src/server/cards/rebalanced/MiningGuildRebalanced.ts
+++ b/src/server/cards/rebalanced/MiningGuildRebalanced.ts
@@ -1,0 +1,70 @@
+import {Tag} from '../../../common/cards/Tag';
+import {IPlayer} from '../../IPlayer';
+import {Phase} from '../../../common/Phase';
+import {Space} from '../../boards/Space';
+import {SpaceBonus} from '../../../common/boards/SpaceBonus';
+import {Resource} from '../../../common/Resource';
+import {CardName} from '../../../common/cards/CardName';
+import {GainProduction} from '../../deferredActions/GainProduction';
+import {CardRenderer} from '../render/CardRenderer';
+import {BoardType} from '../../boards/BoardType';
+import {digit} from '../Options';
+import {AresHandler} from '../../ares/AresHandler';
+import {CorporationCard} from '../corporation/CorporationCard';
+import {Size} from '../../../common/cards/render/Size';
+
+export class MiningGuildRebalanced extends CorporationCard {
+  constructor() {
+    super({
+      name: CardName.MINING_GUILD_REBALANCED,
+      tags: [Tag.BUILDING, Tag.BUILDING],
+      startingMegaCredits: 30,
+
+      behavior: {
+        production: {steel: 1},
+        stock: {steel: 5},
+      },
+
+      metadata: {
+        cardNumber: 'RB-CORP-14',
+        hasExternalHelp: true,
+        description: 'You start with 30 M€, 5 steel and 1 steel production.',
+        renderData: CardRenderer.builder((b) => {
+          b.br.br;
+          b.megacredits(30).nbsp.steel(5, {digit}).nbsp.production((pb) => pb.steel(1));
+          b.corpBox('effect', (ce) => {
+            ce.vSpace(Size.MEDIUM);
+            ce.effect('Each time you place a tile on an area with a steel or titanium placement bonus, increase your steel production 1 step', (eb) => {
+              eb.steel(1).asterix().slash().titanium(1).asterix();
+              eb.startEffect.production((pb) => pb.steel(1));
+            });
+            ce.effect('STEEL MAY BE USED for the CITY STANDARD PROJECT as if you were playing a building card.', (eb) => {
+              eb.city().asterix().startEffect.megacredits(25).super((b) => b.steel(1));
+            });
+          });
+        }),
+      },
+    });
+  }
+
+  public onTilePlaced(cardOwner: IPlayer, activePlayer: IPlayer, space: Space, boardType: BoardType) {
+    // Nerfing on The Moon.
+    if (boardType !== BoardType.MARS) {
+      return;
+    }
+    if (cardOwner.id !== activePlayer.id || cardOwner.game.phase === Phase.SOLAR) {
+      return;
+    }
+    // Don't grant a bonus if the card is overplaced (like Ares Ocean City)
+    if (space.tile?.covers !== undefined) {
+      return;
+    }
+    const board = cardOwner.game.board;
+    const grant = space.bonus.some((bonus) => bonus === SpaceBonus.STEEL || bonus === SpaceBonus.TITANIUM) ||
+      AresHandler.anyAdjacentSpaceGivesBonus(board, space, SpaceBonus.STEEL) ||
+      AresHandler.anyAdjacentSpaceGivesBonus(board, space, SpaceBonus.TITANIUM);
+    if (grant) {
+      cardOwner.game.defer(new GainProduction(cardOwner, Resource.STEEL));
+    }
+  }
+}

--- a/src/server/cards/rebalanced/RebalancedCardManifest.ts
+++ b/src/server/cards/rebalanced/RebalancedCardManifest.ts
@@ -8,6 +8,7 @@ import {HelionRebalanced} from './HelionRebalanced';
 import {InterplanetaryCinematicsRebalanced} from './InterplanetaryCinematicsRebalanced';
 import {InventrixRebalanced} from './InventrixRebalanced';
 import {MidasRebalanced} from './MidasRebalanced';
+import {MiningGuildRebalanced} from './MiningGuildRebalanced';
 import {OdysseyRebalanced} from './OdysseyRebalanced';
 import {PristarRebalanced} from './PristarRebalanced';
 import {SolBankRebalanced} from './SolBankRebalanced';
@@ -30,6 +31,7 @@ export const REBALANCED_CARD_MANIFEST = new ModuleManifest({
     [CardName.MIDAS_REBALANCED]: {Factory: MidasRebalanced},
     [CardName.FACTORUM_REBALANCED]: {Factory: FactorumRebalanced},
     [CardName.HELION_REBALANCED]: {Factory: HelionRebalanced},
+    [CardName.MINING_GUILD_REBALANCED]: {Factory: MiningGuildRebalanced},
   },
   preludeCards: {
   },
@@ -51,5 +53,6 @@ export const REBALANCED_CARD_MANIFEST = new ModuleManifest({
     CardName.MIDAS,
     CardName.FACTORUM,
     CardName.HELION,
+    CardName.MINING_GUILD,
   ],
 });

--- a/src/server/cards/rebalanced/RebalancedCardManifest.ts
+++ b/src/server/cards/rebalanced/RebalancedCardManifest.ts
@@ -4,6 +4,7 @@ import {AdhaiHighOrbitConstructionsRebalanced} from './AdhaiHighOrbitConstructio
 import {ArklightRebalanced} from './ArklightRebalanced';
 import {CelesticRebalanced} from './CelesticRebalanced';
 import {FactorumRebalanced} from './FactorumRebalanced';
+import {HelionRebalanced} from './HelionRebalanced';
 import {InterplanetaryCinematicsRebalanced} from './InterplanetaryCinematicsRebalanced';
 import {InventrixRebalanced} from './InventrixRebalanced';
 import {MidasRebalanced} from './MidasRebalanced';
@@ -28,6 +29,7 @@ export const REBALANCED_CARD_MANIFEST = new ModuleManifest({
     [CardName.INVENTRIX_REBALANCED]: {Factory: InventrixRebalanced},
     [CardName.MIDAS_REBALANCED]: {Factory: MidasRebalanced},
     [CardName.FACTORUM_REBALANCED]: {Factory: FactorumRebalanced},
+    [CardName.HELION_REBALANCED]: {Factory: HelionRebalanced},
   },
   preludeCards: {
   },
@@ -48,5 +50,6 @@ export const REBALANCED_CARD_MANIFEST = new ModuleManifest({
     CardName.INVENTRIX,
     CardName.MIDAS,
     CardName.FACTORUM,
+    CardName.HELION,
   ],
 });


### PR DESCRIPTION
### 🛠️ chore(mingyue): 优化明月扩展部分卡牌的文本与资源处理
- 英文描述统一将 "paid" 替换为 "spent"，中文翻译中“支付”改为“消耗”以保持准确性；
- 技术重构：将《连月》《狸克》《资源管理局》中直接操作 `player.megaCredits` 的逻辑，统一改为 `player.stock.add(...)`，增强一致性与日志可追踪性。

### ✨ feat: 添加公司卡牌 RB-CORP-14 - MiningGuild Rebalanced
- 基于原版 Mining Guild 设计的重制版本；
- 新增效果：钢铁资源可用于城市标准项目。

### ✨ feat: 添加公司卡牌 RB-CORP-13 - Helion Rebalanced
- 基于原版 Helion 设计的重制版本；
- 新增效果：每消耗 2 点热能资源，获得 1 M€。