### PR TITLE
feat: 月球和金星轨迹仅在对应扩展开启时激活

### DIFF
--- a/src/server/pathfinders/PathfindersExpansion.ts
+++ b/src/server/pathfinders/PathfindersExpansion.ts
@@ -30,11 +30,11 @@ export class PathfindersExpansion {
 
   public static initialize(game: IGame): PathfindersData {
     return {
-      venus: game.tags.includes(Tag.VENUS) ? 0 : -1,
+      venus: game.gameOptions.venusNextExtension ? 0 : -1,
       earth: 0,
       mars: 0,
       jovian: 0,
-      moon: game.tags.includes(Tag.MOON) ? 0 : -1,
+      moon: game.gameOptions.moonExpansion ? 0 : -1,
       vps: [],
     };
   }


### PR DESCRIPTION
修改 PathfindersExpansion.initialize 方法：
- 月球轨迹（moon）不再根据游戏中是否存在月球标志卡牌判断，而是根据 gameOptions.moonExpansion 初始化。
- 金星轨迹（venus）不再根据游戏中是否存在金星标志卡牌判断，而是根据 gameOptions.venusNextExtension 初始化。

bespokePlay 和 raiseTrackEssense 保持不变，未启用轨迹仍为 -1，不会被推进。