### PR TITLE
fix(card): 修复 World Line Voyager 世界线航行者显示问题

### DIFF
--- a/src/client/components/card/Card.vue
+++ b/src/client/components/card/Card.vue
@@ -1,5 +1,19 @@
 <template>
   <div :class="getCardClasses(card)">
+      <!-- WORLD_LINE_VOYAGER 背景层 -->
+      <div v-if="cardInstance.name === 'World Line Voyager'" class="card-worldline-state">
+        <div
+          class="worldline-image"
+          :class="{ 'worldline-inactive': card.currentWorldline === 1 }"
+          :style="{ backgroundImage: 'url(\'../../../../assets/mingyue/world-line-2.png\')'}"
+        ></div>
+        <div
+          class="worldline-image"
+          :class="{ 'worldline-inactive': card.currentWorldline === 2 }"
+          :style="{ backgroundImage: 'url(\'../../../../assets/mingyue/world-line-1.png\')'}"
+        ></div>
+      </div>
+      <!-- 卡牌文字/UI 层 -->
       <div class="card-content-wrapper" v-i18n @mouseover="hovering = true" @mouseleave="hovering = false">
           <div v-if="!isStandardProject()" class="card-cost-and-tags">
               <CardCost :amount="getCost()" :newCost="getReducedCost()" />
@@ -16,19 +30,6 @@
         <div class="card-lastpay-counter-number">
           {{ lastCardCost }}
         </div>
-      </div>
-      <!-- 👇 仅对 WORLD_LINE_VOYAGER 显示 -->
-      <div v-if="cardInstance.name === 'World Line Voyager'" class="card-worldline-state">
-        <div
-          class="worldline-image"
-          :class="{ 'worldline-inactive': card.currentWorldline === 1 }"
-          :style="{ backgroundImage: 'url(\'../../../../assets/mingyue/world-line-2.png\')'}"
-        ></div>
-        <div
-          class="worldline-image"
-          :class="{ 'worldline-inactive': card.currentWorldline === 2 }"
-          :style="{ backgroundImage: 'url(\'../../../../assets/mingyue/world-line-1.png\')'}"
-        ></div>
       </div>
       <CardResourceCounter v-if="hasResourceType" :amount="getResourceAmount()" :type="resourceType" />
       <CardExtraContent :card="card" />

--- a/src/styles/mingyue.less
+++ b/src/styles/mingyue.less
@@ -158,7 +158,6 @@
     align-items: center;
     justify-content: center;
     pointer-events: none;
-    z-index: -1;
 }
 
 .worldline-image {


### PR DESCRIPTION
- 将 card-worldline-state 元素移动到卡牌背景层，避免被背景遮挡。
- 移除 z-index 调整，使用 DOM 顺序控制显示层次。
- 确保在正常和缩放卡牌尺寸下，世界线图标都能正确显示，并且不遮挡文字和 UI 元素。