### PR TITLE
 feat: 平衡性调整、代码重构与文本优化

### DIFF
--- a/src/locales/cn/mingyue_corporations.json
+++ b/src/locales/cn/mingyue_corporations.json
@@ -81,7 +81,7 @@
   "Flowing Cloud": "流云",
   "FLOWING CLOUD": "流云",
   "You start with 48 M€. As your first action, draw a floater card.": "起始获得48M€。作为第一个行动，抽一张云载体牌。",
-  "Action: Move any number of floater resources from one floater card to another.": "行动：将任意数量的云从一张云载体牌移动到另一张云载体牌上。",
+  "Action: Move up to half of the floater resources from one floater card to another.": "行动：将至多一半的云从一张云载体牌移动到另一张云载体牌上。",
   "If the two cards have the same number of floater resources after moving, place 1 floater resource on each of these two cards.": "如果移动后两张牌上的云数量相同，则在这两张牌上各放置1个云。",
   "equal": "相等",
 

--- a/src/locales/cn/promo_corporations.json
+++ b/src/locales/cn/promo_corporations.json
@@ -6,7 +6,7 @@
 
   "Astrodrill": "天体钻井",
   "You start with 35 M€ and 3 asteroid resources.": "起始获得35M€和3个小行星资源。",
-  "Action: Add an asteroid resource to ANY card OR gain any standard resource, OR remove an asteroid resource from this card to gain 3 titanium.": "行动：选择在任意卡牌添加1个小行星资源并获得1个标准资源，或移除此卡1个小行星资源获得3个钛。",
+  "Action: Add an asteroid resource to ANY card OR gain any standard resource, OR remove an asteroid resource from this card to gain 3 titanium.": "行动：在任意卡牌上添加1个小行星资源，或获得1个任意标准资源；或移除此卡上的1个小行星资源并获得3个钛。",
 
   "FACTORUM": "FACTORUM",
   "You start with 37 M€. Increase your steel production 1 step.": "起始获得37M€。提升1点钢铁产能。",

--- a/src/locales/cn/rebalanced_corporations.json
+++ b/src/locales/cn/rebalanced_corporations.json
@@ -53,7 +53,8 @@
   "PRISTAR_REBALANCED": "PRISTAR",
   "Pristar Rebalanced": "Pristar",
   "PRISTAR REBALANCED": "PRISTAR",
-  "Effect: During production phase, if you did not get TR so far this generation, or if you have the lowest TR, add one preservation resource here and gain 6 M€.": "效果：在生产阶段，若你本时代未提升改造度，或改造度为全场最低，获得6M€并添加1个卫资源。",
+  "You start with 60 M€. Decrease your TR 3 steps. 1 VP per preservation resource here.": "起始获得60 M€，降低3点改造度。此卡每有1个卫资源获得1VP。",
+  "Effect: During production phase, if you did not get TR so far this generation, or if you have the lowest TR, add one preservation resource here and gain 6 M€.": "效果：在生产阶段，若你本时代未提升改造度，或改造度为全场唯一最低，获得6M€并添加1个卫资源。",
 
   "Adhai_High_Orbit_Constructions_Rebalanced": "Adhai High Orbit Constructions",
   "ADHAI_HIGH_ORBIT_CONSTRUCTIONS_REBALANCED": "ADHAI HIGH ORBIT CONSTRUCTIONS",

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -80,7 +80,6 @@ import {newStandardDraft} from './Draft';
 import {Message} from '../common/logs/Message';
 import {DiscordId} from './server/auth/discord';
 import {AlliedParty, PolicyId} from '../common/turmoil/Types';
-import {GoldenFinger} from './cards/mingyue/corporations/GoldenFinger';
 import {WorldLineVoyager} from './cards/mingyue/corporations/WorldLineVoyager';
 import {getWorldLineVoyagerData} from './mingyue/MingYueData';
 import {SelectAmount} from './inputs/SelectAmount';
@@ -1024,10 +1023,7 @@ export class Player implements IPlayer {
         this.game.log('${0} used ${1} action', (b) => b.player(this).card(card));
         const action = card.action(this);
         this.defer(action);
-        // 过滤掉 GoldenFinger 不加入 actionsThisGeneration
-        if (!(card instanceof GoldenFinger)) {
-          this.actionsThisGeneration.add(card.name);
-        }
+        this.actionsThisGeneration.add(card.name);
         return undefined;
       });
   }
@@ -1049,10 +1045,7 @@ export class Player implements IPlayer {
         this.game.log('${0} used ${1} action', (b) => b.player(this).card(card));
         const action = card.action(this);
         this.defer(action);
-        // 过滤掉 GoldenFinger 不加入 actionsThisGeneration
-        if (!(card instanceof GoldenFinger)) {
-          this.actionsThisGeneration.add(card.name);
-        }
+        this.actionsThisGeneration.add(card.name);
       }
       return undefined;
     });

--- a/src/server/cards/mingyue/AsteroidMaterialResearchCenter.ts
+++ b/src/server/cards/mingyue/AsteroidMaterialResearchCenter.ts
@@ -83,6 +83,12 @@ export class AsteroidMaterialResearchCenter extends Card implements IProjectCard
       return undefined;
     });
   }
+
+  public onProductionPhase(player: IPlayer): undefined {
+    const data = getAsteroidMaterialResearchCenterData(player.game);
+    data.refreshCounter = {};
+    return undefined;
+  }
 }
 
 /**
@@ -106,13 +112,6 @@ class RefreshBlueCardAction extends DeferredAction {
 
     const game = player.game;
     const data = getAsteroidMaterialResearchCenterData(game);
-    const currentGeneration = game.generation;
-
-    // 新的一代，重置刷新计数器
-    if (data.counterGeneration !== currentGeneration) {
-      data.refreshCounter = {};
-      data.counterGeneration = currentGeneration;
-    }
 
     const currentCount = data.refreshCounter[card.name] ?? 0;
     if (currentCount >= 2) return;

--- a/src/server/cards/mingyue/corporations/FlowingCloud.ts
+++ b/src/server/cards/mingyue/corporations/FlowingCloud.ts
@@ -30,9 +30,10 @@ export class FlowingCloud extends CorporationCard {
           b.megacredits(48).nbsp.cards(1, {secondaryTag: AltSecondaryTag.FLOATER});
           b.corpBox('action', (cb) => {
             cb.vSpace(Size.MEDIUM);
-            cb.action('Move any number of floater resources from one floater card to another.',
+            // 修改点 1：更新行动描述
+            cb.action('Move up to half of the floater resources from one floater card to another.',
               (eb) => {
-                eb.minus().text('x').resource(CardResource.FLOATER).startAction.plus().text('x').resource(CardResource.FLOATER);
+                eb.minus().text('x').resource(CardResource.FLOATER).asterix().startAction.plus().text('x').resource(CardResource.FLOATER);
               },
             );
             cb.plainEffect('If the two cards have the same number of floater resources after moving, place 1 floater resource on each of these two cards.',
@@ -51,17 +52,19 @@ export class FlowingCloud extends CorporationCard {
     if (floaterCards.length < 2) {
       return false; // 不够 2 张云载体，不能行动
     }
-    // 至少有一张云载体含有云资源即可
-    return floaterCards.some((card) => card.resourceCount > 0);
+    // 至少有一张云载体含有至少2个云资源即可
+    return floaterCards.some((card) => card.resourceCount >= 2);
   }
 
   public action(player: IPlayer) {
     const floaterCards = player.tableau.filter((card) => card.resourceType === CardResource.FLOATER);
-    const sourceCandidates = floaterCards.filter((card) => card.resourceCount > 0);
+    // 修改点 2：来源卡至少需要有2个云资源
+    const sourceCandidates = floaterCards.filter((card) => card.resourceCount >= 2);
 
-    return new SelectCard('选择来源云载体（含云资源）', '选择', sourceCandidates, {min: 1, max: 1}).andThen(
+    return new SelectCard('选择来源云载体（至少含2个云资源）', '选择', sourceCandidates, {min: 1, max: 1}).andThen(
       ([sourceCard]) => {
-        const maxMove = sourceCard.resourceCount;
+        // 修改点 3：最大移动数量为资源数的一半（向下取整）
+        const maxMove = Math.floor(sourceCard.resourceCount / 2);
         return new SelectAmount(`选择移动的云资源数量（最多 ${maxMove}）`, '确定', 1, maxMove).andThen(
           (amount) => {
             const targetCandidates = floaterCards.filter((card) => card !== sourceCard);

--- a/src/server/cards/mingyue/corporations/GoldenFinger.ts
+++ b/src/server/cards/mingyue/corporations/GoldenFinger.ts
@@ -150,6 +150,11 @@ export class GoldenFinger extends CorporationCard {
         });
     });
 
+    // A hack that allows this action to be replayable.
+    player.defer(() => {
+      player.actionsThisGeneration.delete(this.name);
+    });
+
     return new OrOptions(
       useBlueCard,
       playCard,

--- a/src/server/cards/rebalanced/FactorumRebalanced.ts
+++ b/src/server/cards/rebalanced/FactorumRebalanced.ts
@@ -31,7 +31,7 @@ export class FactorumRebalanced extends CorporationCard implements IActionCard {
               eb.text('least').energy(1).startAction.production((pb) => pb.energy(1));
             });
             ce.action('If you have (or are tied for) the most steel resources, draw a building card.', (eb) => {
-              eb.text('most').steel(1).startAction.cards(1, {secondaryTag: Tag.BUILDING});
+              eb.or().nbsp.text('most').steel(1).startAction.cards(1, {secondaryTag: Tag.BUILDING});
             });
           });
         }),

--- a/src/server/cards/rebalanced/PristarRebalanced.ts
+++ b/src/server/cards/rebalanced/PristarRebalanced.ts
@@ -5,22 +5,28 @@ import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {Resource} from '../../../common/Resource';
 import {Pristar} from '../turmoil/Pristar';
+import {digit} from '../Options';
 
 export class PristarRebalanced extends Pristar {
   constructor() {
     super({
       name: CardName.PRISTAR_REBALANCED,
+      startingMegaCredits: 60,
+
+      behavior: {
+        tr: -3,
+      },
 
       metadata: {
         cardNumber: 'RB-CORP-08',
-        description: 'You start with 53 M€. Decrease your TR 2 steps. 1 VP per preservation resource here.',
+        description: 'You start with 60 M€. Decrease your TR 3 steps. 1 VP per preservation resource here.',
 
         renderData: CardRenderer.builder((b) => {
           b.br.br.br;
-          b.megacredits(53).minus().tr(2, {size: Size.SMALL});
+          b.megacredits(60).nbsp.nbsp.minus().tr(3, {size: Size.SMALL, digit});
           b.corpBox('effect', (ce) => {
             ce.effect('During production phase, if you did not get TR so far this generation, or if you have the lowest TR, add one preservation resource here and gain 6 M€.', (eb) => {
-              eb.tr(1, {size: Size.SMALL, cancelled: true}).asterix().startEffect.resource(CardResource.PRESERVATION).megacredits(6);
+              eb.tr(1, {size: Size.SMALL, cancelled: true}).slash().text('least', Size.SMALL).tr(1, {size: Size.SMALL}).asterix().startEffect.resource(CardResource.PRESERVATION).megacredits(6);
             });
           });
         }),

--- a/src/server/cards/turmoil/Pristar.ts
+++ b/src/server/cards/turmoil/Pristar.ts
@@ -9,6 +9,10 @@ import {Resource} from '../../../common/Resource';
 export class Pristar extends CorporationCard {
   constructor({
     name = CardName.PRISTAR,
+    startingMegaCredits = 53,
+    behavior = {
+      tr: -2,
+    },
     metadata = {
       cardNumber: 'R07',
       description: 'You start with 53 M€. Decrease your TR 2 steps. 1 VP per preservation resource here.',
@@ -26,14 +30,12 @@ export class Pristar extends CorporationCard {
   } = {}) {
     super({
       name,
-      startingMegaCredits: 53,
+      startingMegaCredits,
       resourceType: CardResource.PRESERVATION,
 
       victoryPoints: {resourcesHere: {}},
 
-      behavior: {
-        tr: -2,
-      },
+      behavior,
 
       metadata,
     });

--- a/src/server/mingyue/MingYueData.ts
+++ b/src/server/mingyue/MingYueData.ts
@@ -14,7 +14,6 @@ export interface MingYueData {
     lastSetCount: number;
   };
   asteroidMaterialResearchCenter?: {
-    counterGeneration: number;
     refreshCounter: {[cardName: string]: number};
   };
   abnormalTitan?: {
@@ -47,7 +46,6 @@ export namespace MingYueData {
       }),
       ...(data.asteroidMaterialResearchCenter !== undefined && {
         asteroidMaterialResearchCenter: {
-          counterGeneration: data.asteroidMaterialResearchCenter.counterGeneration,
           refreshCounter: data.asteroidMaterialResearchCenter.refreshCounter,
         },
       }),
@@ -79,7 +77,6 @@ export namespace MingYueData {
         } : undefined,
       asteroidMaterialResearchCenter: data.asteroidMaterialResearchCenter ?
         {
-          counterGeneration: data.asteroidMaterialResearchCenter.counterGeneration ?? -1,
           refreshCounter: data.asteroidMaterialResearchCenter.refreshCounter ?? {},
         } : undefined,
       abnormalTitan: data.abnormalTitan ?
@@ -121,7 +118,6 @@ export function getTrisynInstituteData(game: IGame) {
 export function getAsteroidMaterialResearchCenterData(game: IGame) {
   game.mingyueData ??= {};
   game.mingyueData.asteroidMaterialResearchCenter ??= {
-    counterGeneration: -1,
     refreshCounter: {},
   };
   return game.mingyueData.asteroidMaterialResearchCenter;

--- a/src/server/mingyue/MingYueExpansion.ts
+++ b/src/server/mingyue/MingYueExpansion.ts
@@ -18,7 +18,6 @@ export class MingYueExpansion {
         lastSetCount: 0,
       },
       asteroidMaterialResearchCenter: {
-        counterGeneration: -1,
         refreshCounter: {},
       },
       abnormalTitan: {

--- a/src/server/mingyue/SerializedMingYueData.ts
+++ b/src/server/mingyue/SerializedMingYueData.ts
@@ -11,7 +11,6 @@ export interface SerializedMingYueData {
     lastSetCount: number;
   };
   asteroidMaterialResearchCenter?: {
-    counterGeneration?: number;
     refreshCounter?: { [cardName: string]: number };
   };
   abnormalTitan?: {


### PR DESCRIPTION
本次 PR 包含了一系列对自定义扩展卡牌的优化与调整，主要涵盖了三个方面：
1.  对两张公司卡（**流云**、**PRISTAR**）的平衡性进行了调整。
2.  对两张卡牌（**金手指**、**小行星物质研究中心**）的核心机制实现方式进行了重构，显著提升了代码质量和健壮性。
3.  对部分卡牌描述文本进行了润色和优化。

---

### ✨ 功能与平衡性调整 (Features & Balance)

*   **流云 (FlowingCloud):**
    *   将其行动从“移动任意数量的云”修改为“移动至多一半的云（向下取整）”。
    *   增加了来源卡至少需要2个云才能执行行动的限制，以平衡其强度。

*   **PRISTAR (Rebalanced):**
    *   将其初始资源从 `53 M€ / -2 TR` 调整为 `60 M€ / -3 TR`，以进行游戏性平衡。

### 🛠️ 代码重构与优化 (Refactoring & Optimizations)

*   **金手指 (GoldenFinger):**
    *   **重大重构**：移除了之前在 `Player` 类中对“金手指”的硬编码特例。现在，其无限次行动的机制被完全封装在卡牌自身逻辑内（通过 `defer` 在行动后移除行动记录），实现了核心逻辑与特定卡牌的解耦，代码设计更加优雅。

*   **小行星物质研究中心 (AsteroidMaterialResearchCenter):**
    *   将其跨世代刷新计数器的逻辑，从原先在行动中“懒加载式”地判断 `generation` 的方式，重构为使用标准的 `onProductionPhase` 游戏阶段钩子。这使得刷新逻辑更健壮、可靠，并简化了相关的数据模型。

### 📝 文本与翻译优化 (Text & Translation)

*   配合上述卡牌的机制和数值修改，同步更新了相关的中英文描述文本。
*   对部分原有翻译进行了润色，使其更符合游戏语境，提升了玩家的阅读体验。