### PR TITLE
balance: 平衡性调整

### DIFF
--- a/src/locales/cn/mingyue_corporations.json
+++ b/src/locales/cn/mingyue_corporations.json
@@ -1,11 +1,12 @@
 {
-  "You start with 48 M€.": "起始获得48M€。",
+  "You start with 45 M€.": "起始获得45M€。",
   "Effect: After you play a project card, if this completes a new set of red, green, and blue project cards, draw 1 card.": "效果：当你打出项目卡后，若因此新凑齐一套红/绿/蓝项目卡，抽1张牌。",
   "Action: Reveal and discard 2 cards from your hand, then draw 1 card of a color not present among the discarded cards.": "行动：从你的手牌中展示并弃置2张牌，然后抽1张颜色不同于弃置牌的牌。",
   "${0} collected ${1} red-green-blue sets, drew 1 card due to ${2} effect.": "${0} 收集了 ${1} 套红绿蓝，因 ${2} 效果摸了 1 张牌。",
   "${0}'s red-green-blue set count decreased to ${1}.": "${0} 的红绿蓝套数减少到了 ${1}。",
 
   "Luna Chain": "连月",
+  "You start with 48 M€.": "起始获得48M€。",
   "Effect: After you play a project card, if the final M€ paid differs from the previous card by X (absolute value and X ≤ 2), gain (3 - X) M€.": "效果：当你打出项目卡后，若其最终支付的M€与上一张卡的差额为X（取绝对值且X ≤ 2），则获得(3-X) M€。",
   "${0} gained ${1} M€ due to ${2} effect.": "${0} 因 ${2} 效果，获得了 ${1} M€。",
   "${0} has accumulated ${1} M€, averaging ${2} M€ per project card (LunaChain God 🌙)": "${0} 累计获得了 ${1} M€，平均每张项目卡获得 ${2} M€ (连月之神 🌙)",

--- a/src/locales/cn/rebalanced_corporations.json
+++ b/src/locales/cn/rebalanced_corporations.json
@@ -28,6 +28,7 @@
   "CELESTIC_REBALANCED": "CELESTIC",
   "Celestic Rebalanced": "Celestic",
   "CELESTIC REBALANCED": "CELESTIC",
+  "You start with 42 M€. As your first action, draw a floater card.": "起始获得42M€。作为第一个行动，抽一张云载体牌。",
   "Effect: When you gain an floater to ANY CARD, gain 1 M€.": "效果：当你在任意卡上增加1个云资源时，获得1M€。",
 
   "SolBank_Rebalanced": "SolBank",
@@ -126,6 +127,7 @@
   "STORMCRAFT_INCORPORATED_REBALANCED": "STORMCRAFT_INCORPORATED",
   "Stormcraft Incorporated Rebalanced": "Stormcraft Incorporated",
   "STORMCRAFT INCORPORATED REBALANCED": "STORMCRAFT INCORPORATED",
+  "You start with 45 M€. As your first action, draw a floater card.": "起始获得45M€。作为第一个行动，抽一张云载体牌。",
   "Action: Add a floater each to 1 or 2 different cards.": "行动：在1或2张不同的卡牌上各放置1个云资源。",
   "Select 2 cards to place 1 floater on each": "选择 2 张卡牌，各放置 1 个云资源",
   "Place": "放置"

--- a/src/server/cards/chemical/DataCenter.ts
+++ b/src/server/cards/chemical/DataCenter.ts
@@ -10,9 +10,9 @@ export class DataCenter extends Card implements IProjectCard {
   constructor() {
     super({
       name: CardName.DATA_CENTER,
-      cost: 9,
+      cost: 10,
       type: CardType.AUTOMATED,
-      tags: [Tag.EARTH],
+      tags: [Tag.EARTH, Tag.MARS],
 
       behavior: {
         addResourcesToAnyCard: {

--- a/src/server/cards/mingyue/MarsMonument.ts
+++ b/src/server/cards/mingyue/MarsMonument.ts
@@ -11,7 +11,7 @@ export class MarsMonument extends Card implements IProjectCard {
     super({
       type: CardType.AUTOMATED,
       name: CardName.MARS_MONUMENT,
-      tags: [Tag.BUILDING],
+      tags: [Tag.BUILDING, Tag.MARS],
       cost: 20,
       requirements: {tr: 35},
       victoryPoints: 5,

--- a/src/server/cards/mingyue/corporations/TrisynInstitute.ts
+++ b/src/server/cards/mingyue/corporations/TrisynInstitute.ts
@@ -22,13 +22,13 @@ export class TrisynInstitute extends CorporationCard {
     super({
       name: CardName.TRISYN_INSTITUTE,
       tags: [Tag.SCIENCE],
-      startingMegaCredits: 48,
+      startingMegaCredits: 45,
 
       metadata: {
         cardNumber: 'MY-CORP-01',
-        description: 'You start with 48 M€.',
+        description: 'You start with 45 M€.',
         renderData: CardRenderer.builder((b) => {
-          b.megacredits(48);
+          b.megacredits(45);
           b.corpBox('action', (cb) => {
             cb.vSpace(Size.LARGE);
             cb.action('Reveal and discard 2 cards from your hand, then draw 1 card of a color not present among the discarded cards.', (eb) => {

--- a/src/server/cards/rebalanced/CelesticRebalanced.ts
+++ b/src/server/cards/rebalanced/CelesticRebalanced.ts
@@ -1,22 +1,43 @@
 import {IPlayer} from '../../IPlayer';
+import {Tag} from '../../../common/cards/Tag';
 import {CardResource} from '../../../common/CardResource';
+import {ActiveCorporationCard} from '../corporation/CorporationCard';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {AltSecondaryTag} from '../../../common/cards/render/AltSecondaryTag';
-import {ICard} from '../ICard';
-import {Resource} from '../../../common/Resource';
-import {Celestic} from '../venusNext/Celestic';
 import {Size} from '../../../common/cards/render/Size';
+import {Resource} from '../../../common/Resource';
+import {ICard} from '../ICard';
+import {CardType} from '../../../common/cards/CardType';
 
-export class CelesticRebalanced extends Celestic {
+export class CelesticRebalanced extends ActiveCorporationCard {
   constructor() {
     super({
       name: CardName.CELESTIC_REBALANCED,
+      tags: [Tag.VENUS],
+      startingMegaCredits: 42,
+      resourceType: CardResource.FLOATER,
+
+      victoryPoints: {resourcesHere: {}, per: 3},
+
+      firstAction: {
+        text: 'Draw a floater card',
+        drawCard: {count: 1, type: CardType.ACTIVE, resource: CardResource.FLOATER},
+      },
+
+      action: {
+        addResourcesToAnyCard: {
+          type: CardResource.FLOATER,
+          count: 1,
+          autoSelect: true,
+        },
+      },
+
       metadata: {
         cardNumber: 'RB-CORP-04',
-        description: 'You start with 42 M€. As your first action, reveal cards from the deck until you have revealed 2 cards with a floater icon on it. Take them into hand and discard the rest.',
+        description: 'You start with 42 M€. As your first action, draw a floater card.',
         renderData: CardRenderer.builder((b) => {
-          b.megacredits(42).nbsp.cards(2, {secondaryTag: AltSecondaryTag.FLOATER});
+          b.megacredits(42).nbsp.cards(1, {secondaryTag: AltSecondaryTag.FLOATER});
           b.corpBox('action', (ce) => {
             ce.vSpace(Size.LARGE);
             ce.action('Add a floater to ANY card. 1 VP per 3 floaters on this card.', (eb) => {

--- a/src/server/cards/rebalanced/StormcraftIncorporatedRebalanced.ts
+++ b/src/server/cards/rebalanced/StormcraftIncorporatedRebalanced.ts
@@ -12,21 +12,28 @@ import {Resource} from '../../../common/Resource';
 import {message} from '../../logs/MessageBuilder';
 import {SelectCard} from '../../inputs/SelectCard';
 import {IActionCard} from '../ICard';
+import {CardType} from '../../../common/cards/CardType';
+import {AltSecondaryTag} from '../../../common/cards/render/AltSecondaryTag';
 
 export class StormcraftIncorporatedRebalanced extends CorporationCard implements IActionCard {
   constructor() {
     super({
       name: CardName.STORMCRAFT_INCORPORATED_REBALANCED,
       tags: [Tag.JOVIAN],
-      startingMegaCredits: 48,
+      startingMegaCredits: 45,
       resourceType: CardResource.FLOATER,
+
+      firstAction: {
+        text: 'Draw a floater card',
+        drawCard: {count: 1, type: CardType.ACTIVE, resource: CardResource.FLOATER},
+      },
 
       metadata: {
         cardNumber: 'RB-CORP-18',
-        description: 'You start with 48 M€.',
+        description: 'You start with 45 M€. As your first action, draw a floater card.',
         renderData: CardRenderer.builder((b) => {
           b.br.br.br;
-          b.megacredits(48);
+          b.megacredits(45).nbsp.cards(1, {secondaryTag: AltSecondaryTag.FLOATER});
           b.corpBox('action', (ce) => {
             ce.vSpace(Size.LARGE);
             ce.action('Add a floater each to 1 or 2 different cards.', (eb) => {

--- a/src/server/cards/venusNext/Celestic.ts
+++ b/src/server/cards/venusNext/Celestic.ts
@@ -8,24 +8,9 @@ import {AltSecondaryTag} from '../../../common/cards/render/AltSecondaryTag';
 import {floaterCards} from './floaterCards';
 
 export class Celestic extends ActiveCorporationCard {
-  constructor({
-    name = CardName.CELESTIC,
-    metadata = {
-      cardNumber: 'R05',
-      description: 'You start with 42 M€. As your first action, reveal cards from the deck until you have revealed 2 cards with a floater icon on it. Take them into hand and discard the rest.',
-      renderData: CardRenderer.builder((b) => {
-        b.megacredits(42).nbsp.cards(2, {secondaryTag: AltSecondaryTag.FLOATER});
-        b.corpBox('action', (ce) => {
-          ce.action('Add a floater to ANY card. 1 VP per 3 floaters on this card.', (eb) => {
-            eb.empty().startAction.resource(CardResource.FLOATER).asterix();
-          });
-          ce.vSpace(); // to offset the description to the top a bit so it can be readable
-        });
-      }),
-    },
-  } = {}) {
+  constructor() {
     super({
-      name,
+      name: CardName.CELESTIC,
       tags: [Tag.VENUS],
       startingMegaCredits: 42,
       resourceType: CardResource.FLOATER,
@@ -40,9 +25,22 @@ export class Celestic extends ActiveCorporationCard {
         },
       },
 
-      metadata,
+      metadata: {
+        cardNumber: 'R05',
+        description: 'You start with 42 M€. As your first action, reveal cards from the deck until you have revealed 2 cards with a floater icon on it. Take them into hand and discard the rest.',
+        renderData: CardRenderer.builder((b) => {
+          b.megacredits(42).nbsp.cards(2, {secondaryTag: AltSecondaryTag.FLOATER});
+          b.corpBox('action', (ce) => {
+            ce.action('Add a floater to ANY card. 1 VP per 3 floaters on this card.', (eb) => {
+              eb.empty().startAction.resource(CardResource.FLOATER).asterix();
+            });
+            ce.vSpace(); // to offset the description to the top a bit so it can be readable
+          });
+        }),
+      },
     });
   }
+
 
   public initialAction(player: IPlayer) {
     player.drawCard(2, {


### PR DESCRIPTION
- Trisyn Institute (三元学院) 起始资金从 48M€ 调整到 45M€。
- Celestic (原版) 回退到修改前的状态。
- CelesticRebalanced（重制版）重写代码，避免继承原版。起始资金 42M€，第一个行动改为抽一张云载体牌。
- Stormcraft Incorporated（重制版）起始资金从 48M€ 调整到 45M€，并增加第一个行动：抽一张云载体牌。
- DataCenter (数据中心) 增加火星标签，费用从 9M€ 调整到 10M€。
- MARS_MONUMENT (火星纪念碑) 增加火星标签。
- 相应更新了中文描述文件。